### PR TITLE
Load table data with recordset to avoid memory issues

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -189,7 +189,7 @@ switch ($do) {
 
             $output .= "== ".$table." ==\r\n\r\n";
 
-            if ($data = $DB->get_records($table)) {
+            if ($data = $DB->get_recordset($table)) {
 
                 $headers = array_keys(get_object_vars(current($data)));
                 $columnwidth = 25;


### PR DESCRIPTION
When accessing 'viewreport' or 'savereport' from the settings page, the
report loads ALL the records from the config and files tables.

For large datasets, this is ALOT of data and fills up memory fast. By
using get_recordset instead, the entire dataset isn't loaded into memory
at once, avoiding an out-of-memory error on these pages.