### PR TITLE
Add paging bar to errors report

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -244,6 +244,7 @@ switch ($do) {
         break;
 
     case "errors":
+        $page = optional_param('page', 0, PARAM_INT);
         $resubmitted = optional_param('resubmitted', '', PARAM_ALPHA);
         $turnitinpluginview->draw_settings_tab_menu('turnitinerrors', $notice);
         echo html_writer::tag("p", get_string('pperrorsdesc', 'turnitintooltwo'));
@@ -259,7 +260,7 @@ switch ($do) {
         echo html_writer::tag("button", get_string('resubmitselected', 'turnitintooltwo'),
                                 array("class" => "btn btn-primary pp-resubmit-files", "disabled" => "disabled"));
 
-        echo $turnitinpluginview->show_file_errors_table();
+        echo $turnitinpluginview->show_file_errors_table($page);
 
         echo html_writer::tag("button", get_string('resubmitselected', 'turnitintooltwo'),
                                 array("class" => "btn btn-primary pp-resubmit-files", "disabled" => "disabled"));

--- a/turnitinplugin_view.class.php
+++ b/turnitinplugin_view.class.php
@@ -413,11 +413,18 @@ class turnitinplugin_view {
         }
     }
 
-    public function show_file_errors_table() {
+    public function show_file_errors_table($page = 0) {
         global $CFG, $OUTPUT;
 
+        $limit = 100;
+        $offset = $page * $limit;
+
         $plagiarismpluginturnitin = new plagiarism_plugin_turnitin();
-        $files = $plagiarismpluginturnitin->get_file_upload_errors();
+        $filescount = $plagiarismpluginturnitin->get_file_upload_errors(0, 0, true);
+        $files = $plagiarismpluginturnitin->get_file_upload_errors($offset, $limit);
+
+        $baseurl = new moodle_url('/plagiarism/turnitin/settings.php', array('do' => 'errors'));
+        $pagingbar = $OUTPUT->paging_bar($filescount, $page, $limit, $baseurl);
 
         // Do the table headers.
         $cells = array();
@@ -530,7 +537,7 @@ class turnitinplugin_view {
         $table->data = $rows;
         $output = html_writer::table($table);
 
-        return $output;
+        return $pagingbar.$output.$pagingbar;
     }
 
     /**


### PR DESCRIPTION
When viewing the errors report - for large institutions you can have a
long list of errors - when typically you're only interested in recent
ones.

This change adds a paging bar to the top and bottom of the report and
has it display 100 records per page.

The underlying record lookup is also adjusted to only load the 100
records related to the page - instead of ALL of them, reducing the
memory footprint considerably.