### PR TITLE
rectified bug of unset variable

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -990,8 +990,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
 
         // This comment is here as it is useful for product support.
-        $output .= html_writer::tag('span', '
-                    <!-- Turnitin Plagiarism plugin Version: '.get_config('plagiarism_turnitin', 'version').' Course ID: '.$coursedata->turnitin_cid.' TII assignment ID: '.$plagiarismsettings['turnitin_assignid'].' -->');
+        $plagiarismsettings = $this->get_settings($cm);
+        $output .= html_writer::tag(
+            'span', '<!-- Turnitin Plagiarism plugin Version: '.get_config('plagiarism_turnitin', 'version').' Course ID: '.$coursedata->turnitin_cid.' TII assignment ID: '.$plagiarismsettings['turnitin_assignid'].' -->');
 
         return $output;
     }


### PR DESCRIPTION
#### Summary
- Set `$plagiarismsettings` using line borrowed from another function, feeding in `$cm` as parameter.
- Tidied up the code producing the comment