### PR TITLE
Duedate update

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -27,7 +27,7 @@
                 <FIELD NAME="errormsg" TYPE="text" LENGTH="medium" NOTNULL="false" SEQUENCE="false" PREVIOUS="errorcode" NEXT="student_read"/>
                 <FIELD NAME="student_read" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false" PREVIOUS="errormsg" NEXT="gm_feedback"/>
                 <FIELD NAME="gm_feedback" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="student_read" NEXT="duedate_report_refresh"/>
-                <FIELD NAME="duedate_report_refresh" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="gm_feedback"/>
+                <FIELD NAME="duedate_report_refresh" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="0 => Report does not need updating, 1 => Originality report needs to be updated, 2 => Report has been updated" PREVIOUS="gm_feedback"/>
             </FIELDS>
             <KEYS>
                 <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="cm"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -26,7 +26,8 @@
                 <FIELD NAME="errorcode" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" PREVIOUS="orcapable" NEXT="errormsg"/>
                 <FIELD NAME="errormsg" TYPE="text" LENGTH="medium" NOTNULL="false" SEQUENCE="false" PREVIOUS="errorcode" NEXT="student_read"/>
                 <FIELD NAME="student_read" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false" PREVIOUS="errormsg" NEXT="gm_feedback"/>
-                <FIELD NAME="gm_feedback" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="student_read"/>
+                <FIELD NAME="gm_feedback" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="student_read" NEXT="duedate_report_refresh"/>
+                <FIELD NAME="duedate_report_refresh" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="gm_feedback"/>
             </FIELDS>
             <KEYS>
                 <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="cm"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -181,7 +181,14 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
+    }
 
+    if ($oldversion < 2015040113) {
+        $table = new xmldb_table('plagiarism_turnitin_files');
+        $field = new xmldb_field('duedate_report_refresh', XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, true, false 0,'gm_feedback');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
     }
 
     return $result;

--- a/lib.php
+++ b/lib.php
@@ -1591,15 +1591,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $dtdue = strtotime('+1 day');
         }
 
-        // Updates the db field 'duedate_report_refresh' if the due date has passed within the last twenty four hours.
-        $now = strtotime('now');
-        if ($now >= $dtdue && $now < strtotime('+1 day',$dtdue)) {
-            $udpate_data = new stdClass();
-            $update_data->id = $DB->get_record('plagiarism_turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_assignid'), 'value');
-            $update_data->duedate_report_refresh = 1;
-            $DB->update_record('duedate_report_refresh', $update_data);
-        }
-
         $assignment->setDueDate(gmdate("Y-m-d\TH:i:s\Z", $dtdue));
         $assignment->setFeedbackReleaseDate(gmdate("Y-m-d\TH:i:s\Z", $dtpost));
 
@@ -1726,8 +1717,19 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Add submission ids to the request.
         foreach ($submissions as $tiisubmission) {
+
             // Only add the submission to the request if the module still exists.
             if ($cm = get_coursemodule_from_id('', $tiisubmission->cm)) {
+
+                // Updates the db field 'duedate_report_refresh' if the due date has passed within the last twenty four hours.
+                $now = strtotime('now');
+                if ($now >= $dtdue && $now < strtotime('+1 day',$dtdue)) {
+                    $udpate_data = new stdClass();
+                    $update_data->id = $DB->get_record('plagiarism_turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_assignid'), 'value');
+                    $update_data->duedate_report_refresh = 1;
+                    $DB->update_record('plagiarism_turnitin_files', $update_data);
+                }
+
                 if (!isset($reportsexpected[$cm->id])) {
                     $plagiarismsettings = $this->get_settings($cm->id);
                     $reportsexpected[$cm->id] = 1;

--- a/lib.php
+++ b/lib.php
@@ -1696,7 +1696,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             try {
                 $typefield = ($CFG->dbtype == "oci") ? " to_char(submissiontype) " : " submissiontype ";
                 $submissions = $DB->get_records_select('plagiarism_turnitin_files',
-                " statuscode = ? AND ".$typefield." = ? AND similarityscore IS NULL AND ( orcapable = ? OR orcapable IS NULL ) ",
+                " (statuscode = ? AND ".$typefield." = ? AND similarityscore IS NULL AND ( orcapable = ? OR orcapable IS NULL )) AND ( (statuscode = ? AND ".$typefield." = ? AND similarityscore IS NULL AND ( orcapable = ? OR orcapable IS NULL )) OR duedate_report_refresh = 1 )",
                 array('success', $submissiontype, 1), 'externalid DESC');
                 $this->cron_update_scores($submissiontype, $submissions);
             } catch (Exception $ex) {
@@ -1710,7 +1710,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     /*  Move the $submissions variable assignment from inside the cron_update_scores and into cron() within the try statement.
         Add this as a second parameter to cron_update_scores, thus the set of submissions to process are determined outside of the cron updater rather than by it.
         Finally, add an extension of logic to the $submissions variable to include the items where your syncreport flag is true. Logic should look like:
-        [current_logic] AND ([current_logic] OR [flag set to true])
+        [current_logic] AND ([current_logic] OR [flag set to true]) -- done
     */
 
     /**

--- a/lib.php
+++ b/lib.php
@@ -1596,7 +1596,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         // If the duedate is in the future then set any submission duedate_report_refresh flags that are 2 to 1 to make sure they are re-examined in the next cron run
         $now = strtotime('now')
         if ($assignment->getDueDate() > $now) {
-            $DB->set_field('plagiarism_turnitin_files', 'duedate_report_refresh', 2, array('cm' => $cm->id));
+            $DB->set_field('plagiarism_turnitin_files', 'duedate_report_refresh', 1, array('cm' => $cm->id, 'duedate_report_refresh' => 2));
         }
 
         $assignment->setFeedbackReleaseDate(gmdate("Y-m-d\TH:i:s\Z", $dtpost));

--- a/lib.php
+++ b/lib.php
@@ -1591,7 +1591,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $dtdue = strtotime('+1 day');
         }
 
-        // Enter a section here that updates the db field if the due date has passed within the last twenty four hours.
+        // Updates the db field 'duedate_report_refresh' if the due date has passed within the last twenty four hours.
+        $now = strtotime('now');
+        if ($now >= $dtdue && $now < strtotime('+1 day',$dtdue)) {
+            $DB->get_record('plagiarism_turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_assignid'), 'value')
+        }
 
         $assignment->setDueDate(gmdate("Y-m-d\TH:i:s\Z", $dtdue));
         $assignment->setFeedbackReleaseDate(gmdate("Y-m-d\TH:i:s\Z", $dtpost));

--- a/lib.php
+++ b/lib.php
@@ -1591,6 +1591,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $dtdue = strtotime('+1 day');
         }
 
+        // Enter a section here that updates the db field if the due date has passed within the last twenty four hours.
+
         $assignment->setDueDate(gmdate("Y-m-d\TH:i:s\Z", $dtdue));
         $assignment->setFeedbackReleaseDate(gmdate("Y-m-d\TH:i:s\Z", $dtpost));
 
@@ -1691,6 +1693,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
         return true;
     }
+
+/* Move the $submissions variable assignment from inside the cron_update_scores and into cron() within the try statement.
+ Add this as a second parameter to cron, thus the set of submissions to process are determined outside of the cron updater rather than by it.
+ Finally, add an extension of logic to the $submissions variable to include the items where your syncreport flag is true. Logic should look like:
+ [current_logic] AND ([current_logic] OR [flag set to true]) */
 
     /**
      * Update simliarity scores.
@@ -1901,7 +1908,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         STATIC $ppDisplayCount = 0;
 
         if (!$ppDisplayCount) {
-            $numEvents = $DB->count_records_sql("SELECT count(*) FROM {events_queue} q 
+            $numEvents = $DB->count_records_sql("SELECT count(*) FROM {events_queue} q
             LEFT JOIN {events_queue_handlers} h ON (h.queuedeventid = q.id)
             LEFT JOIN {events_handlers} e ON (h.handlerid = e.id)
             WHERE e.eventname IN ('assessable_file_uploaded', 'assessable_files_done', 'assessable_content_uploaded', 'assessable_submitted') AND component = 'plagiarism_turnitin'");

--- a/lib.php
+++ b/lib.php
@@ -1595,7 +1595,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $now = strtotime('now');
         if ($now >= $dtdue && $now < strtotime('+1 day',$dtdue)) {
             $udpate_data = new stdClass();
-            $update_data->id = $DB->get_record('plagiarism_turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_assignid'), 'value'); // Gets me an ID.
+            $update_data->id = $DB->get_record('plagiarism_turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_assignid'), 'value');
             $update_data->duedate_report_refresh = 1;
             $DB->update_record('duedate_report_refresh', $update_data);
         }
@@ -1707,10 +1707,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         return true;
     }
 
-    /* Move the $submissions variable assignment from inside the cron_update_scores and into cron() within the try statement.
-     Add this as a second parameter to cron_update_scores, thus the set of submissions to process are determined outside of the cron updater rather than by it.
-     Finally, add an extension of logic to the $submissions variable to include the items where your syncreport flag is true. Logic should look like:
-     [current_logic] AND ([current_logic] OR [flag set to true]) */
+    /*  Move the $submissions variable assignment from inside the cron_update_scores and into cron() within the try statement.
+        Add this as a second parameter to cron_update_scores, thus the set of submissions to process are determined outside of the cron updater rather than by it.
+        Finally, add an extension of logic to the $submissions variable to include the items where your syncreport flag is true. Logic should look like:
+        [current_logic] AND ([current_logic] OR [flag set to true])
+    */
 
     /**
      * Update simliarity scores.


### PR DESCRIPTION
### Summary
- Created new field in database to signify whether a submission needs to have the OR re-synced after the expiration of a due date.
    - Updated upgrade.php
    - field values:
        - 0 => default, submission existed before this was all rolled out, or the due date has not yet passed.
        - 1 => assignment OR report needs to be re-synced.
        - 2 => assignment OR has already been re-synced.
- Upon setting the due date for an assignment, if that due date is in the future, then the duedate_report_refresh flag for each submission is set to 1 wherever it was previously 2. Otherwise, no change. 
- When cron runs, each submission subject to a due date that passed within the last twenty four hours will have the duedate_report_refresh flag set from 0 to 1.
    - Once the assignments have had their OR refreshed, the flag is set to 2 to prevent the next cron picking them up.