### PR TITLE
Roles

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -80,10 +80,7 @@ switch ($action) {
 
         $submissionid = optional_param('submission', 0, PARAM_INT);
 
-        $istutor = ($cm->modname == "assign") ? has_capability('mod/'.$cm->modname.':grade', $context) :
-                                                        has_capability('plagiarism/turnitin:viewfullreport', $context);
-
-        if ($istutor && $cm->modname == "assign") {
+        if ($userrole == 'Instructor' && $cm->modname == "assign") {
             $return["status"] = $pluginturnitin->update_grades_from_tii($cm);
 
             $moduleconfigvalue = new stdClass();
@@ -116,17 +113,8 @@ switch ($action) {
         break;
 
     case "peermarkmanager":
-        switch ($cm->modname) {
-            case "forum":
-            case "workshop":
-                $istutor = has_capability('plagiarism/turnitin:viewfullreport', $context);
-                break;
-            default:
-                $istutor = has_capability('mod/'.$cm->modname.':grade', $context);
-                break;
-        }
 
-        if ($istutor) {
+        if ($userrole == 'Instructor') {
             $plagiarism_plugin_turnitin = new plagiarism_plugin_turnitin();
             $coursedata = $plagiarism_plugin_turnitin->get_course_data($cm->id, $cm->course);
 

--- a/ajax.php
+++ b/ajax.php
@@ -80,7 +80,7 @@ switch ($action) {
 
         $submissionid = optional_param('submission', 0, PARAM_INT);
 
-        $istutor = ($cm->modname == "assign") ? $istutor = has_capability('mod/'.$cm->modname.':grade', $context) :
+        $istutor = ($cm->modname == "assign") ? has_capability('mod/'.$cm->modname.':grade', $context) :
                                                         has_capability('plagiarism/turnitin:viewfullreport', $context);
 
         if ($istutor && $cm->modname == "assign") {

--- a/ajax.php
+++ b/ajax.php
@@ -160,20 +160,11 @@ switch ($action) {
         break;
 
     case "peermarkreviews":
-        switch ($cm->modname) {
-            case "forum":
-            case "workshop":
-                $istutor = has_capability('plagiarism/turnitin:viewfullreport', $context);
-                break;
-            default:
-                $istutor = has_capability('mod/'.$cm->modname.':grade', $context);
-                break;
-        }
 
         $isstudent = ($cm->modname == "forum") ? has_capability('mod/'.$cm->modname.':replypost', $context) :
                                                 has_capability('mod/'.$cm->modname.':submit', $context);
 
-        if ($istutor || $isstudent) {
+        if ($userrole == 'Instructor' || $isstudent) {
             $role = ($istutor) ? 'Instructor' : 'Learner';
 
             $tiiassignment = $DB->get_record('plagiarism_turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_assignid'));

--- a/db/access.php
+++ b/db/access.php
@@ -15,7 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 $capabilities = array(
-
     'plagiarism/turnitin:enable' => array(
         'captype' => 'write',
         'contextlevel' => CONTEXT_COURSE,
@@ -24,16 +23,6 @@ $capabilities = array(
          'manager' => CAP_ALLOW
         )
     ),
-
-    'plagiarism/turnitin:viewsimilarityscore' => array(
-        'captype' => 'read',
-        'contextlevel' => CONTEXT_COURSE,
-         'legacy' => array(
-         'editingteacher' => CAP_ALLOW,
-         'manager' => CAP_ALLOW
-        )
-    ),
-
     'plagiarism/turnitin:viewfullreport' => array(
         'captype' => 'read',
         'contextlevel' => CONTEXT_COURSE,

--- a/extras.php
+++ b/extras.php
@@ -39,17 +39,6 @@ $cmid = required_param('cmid', PARAM_INT);
 $cm = get_coursemodule_from_id('', $cmid);
 $context = context_course::instance($cm->course);
 
-// Work out user role.
-switch ($cm->modname) {
-    case "forum":
-    case "workshop":
-        $userrole = (has_capability('plagiarism/turnitin:viewfullreport', $context)) ? 'Instructor' : 'Learner';
-        break;
-    default:
-        $userrole = (has_capability('mod/'.$cm->modname.':grade', $context)) ? 'Instructor' : 'Learner';
-        break;
-}
-
 $PAGE->set_context(context_system::instance());
 require_login();
 

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -105,7 +105,6 @@ $string['course'] = 'Course';
 $string['module'] = 'Module';
 
 // Grade book/View assignment page
-$string['turnitin:viewsimilarityscore'] = 'View Similarity Score';
 $string['turnitin:viewfullreport'] = 'View Originality Report';
 $string['launchrubricview'] = 'View the Rubric used for marking';
 $string['turnitinppulapost'] = 'Your file has not been submitted to Turnitin. Please click here to accept our EULA.';


### PR DESCRIPTION
### Done so far:
- Stripped out unused role
    - Removed associated language string
- Reworked logic in areas that discern user status in ajax.php to utilize variable that is already set.
- Removed `$userrole` definition from extras.php as the variable is unused.

### Notes/Questions:
1. Leaving the reference to `plagiarism/turnitin:enable` in lib.php:201 as there probably isn't a better way to do this.
2. Is it worth investigating further into the possiblity of using Moodle's own definitions of what is / isn't an instructor (to eliminate the risk of role-conflict between the two hierarchies) or is such a situation not very likely to arise?