### PR TITLE
Changed jQuery Loading Priorities 

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -443,8 +443,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     public function load_page_components() {
         global $CFG, $PAGE;
 
-        $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/jquery-1.8.2.min.js');
-        $PAGE->requires->js($jsurl);
+        // Only load jQuery library for moodle 25 or lower. Otherwise borrow Moodle's.
+        if ($CFG->branch <= 25) {
+            $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/jquery-1.8.2.min.js');
+            $PAGE->requires->js($jsurl);
+        } else {
+            $PAGE->requires->jquery();
+        }
+
         $jsurl = new moodle_url($CFG->wwwroot.'/mod/turnitintooltwo/jquery/turnitintooltwo.js');
         $PAGE->requires->js($jsurl);
         $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/turnitin_module.js');


### PR DESCRIPTION
Added catch to logic that loads jQuery 1.8.2 at all times and instead only loads it if the Moodle version is less than 2.6.

[Link to issue in turnitintooltwo](https://github.com/turnitin/moodle-mod_turnitintooltwo/issues/128)