### PR TITLE
jQuery loading

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -443,8 +443,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     public function load_page_components() {
         global $CFG, $PAGE;
 
-        $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/jquery-1.8.2.min.js');
-        $PAGE->requires->js($jsurl);
+        // Only load jQuery library for moodle 25 or lower. Otherwise borrow Moodle's.
+        if ($CFG->branch <= 25) {
+            $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/jquery-1.8.2.min.js');
+            $PAGE->requires->js($jsurl);
+        } else {
+            $PAGE->requires->jquery();
+        }
+
         $jsurl = new moodle_url($CFG->wwwroot.'/mod/turnitintooltwo/jquery/turnitintooltwo.js');
         $PAGE->requires->js($jsurl);
         $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/turnitin_module.js');

--- a/lib.php
+++ b/lib.php
@@ -448,6 +448,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/jquery-1.8.2.min.js');
             $PAGE->requires->js($jsurl);
         } else {
+            // This seems to generate minor error messages in the submission inbox, although the correct jQuery still loads. Weird.
             $PAGE->requires->jquery();
         }
 


### PR DESCRIPTION
Told plugin to load its own packaged jQuery (1.8.2) IFF the Moodle version number is less than 2.6, otherwise use the jQuery version packaged with Moodle.

# Debugging Message Problem
issue #129

`$PAGE->requires->jQuery();` seems to generate some error messages in the submission inbox however these are only visible with debugging set to full or developer. Viewing source shows that the correct jQuery is loaded despite the debugging messages.