### PR TITLE
Add foreign key support and cron error fix

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -30,8 +30,8 @@
             </FIELDS>
             <KEYS>
                 <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="cm"/>
-                <KEY NAME="cm" TYPE="foreign" FIELDS="cm" REFTABLE="course_modules" REFFIELDS="id" PREVIOUS="primary" NEXT="userid"/>
-                <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id" PREVIOUS="cm"/>
+                <KEY NAME="cm" TYPE="foreign" FIELDS="cm" REFTABLE="course_modules" REFFIELDS="id" ONDELETE="cascade" PREVIOUS="primary" NEXT="userid"/>
+                <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id" ONDELETE="cascade" PREVIOUS="cm"/>
             </KEYS>
             <INDEXES>
                 <INDEX NAME="externalid" UNIQUE="false" FIELDS="externalid" />
@@ -40,13 +40,13 @@
         <TABLE NAME="plagiarism_turnitin_config" COMMENT="info about submitted files" PREVIOUS="plagiarism_turnitin_files">
             <FIELDS>
                 <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true" NEXT="cm"/>
-                <FIELD NAME="cm" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="id" NEXT="name"/>
+                <FIELD NAME="cm" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" PREVIOUS="id" NEXT="name"/>
                 <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" PREVIOUS="cm" NEXT="value"/>
                 <FIELD NAME="value" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" PREVIOUS="name"/>
             </FIELDS>
             <KEYS>
                 <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="cm"/>
-                <KEY NAME="cm" TYPE="foreign" FIELDS="cm" REFTABLE="course_modules" REFFIELDS="id" PREVIOUS="primary"/>
+                <KEY NAME="cm" TYPE="foreign" FIELDS="cm" REFTABLE="course_modules" REFFIELDS="id" ONDELETE="cascade" PREVIOUS="primary"/>
             </KEYS>
         </TABLE>
     </TABLES>

--- a/lib.php
+++ b/lib.php
@@ -96,9 +96,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      * @param int $cm_id  the course module id, if this is 0 the default settings will be retrieved
      * @return array of Turnitin settings for a module
      */
-    public function get_settings($cmid = 0) {
+    public function get_settings($cmid = null) {
         global $DB;
-        $defaults = $DB->get_records_menu('plagiarism_turnitin_config', array('cm' => 0),     '', 'name,value');
+        $defaults = $DB->get_records_menu('plagiarism_turnitin_config', array('cm' => null),     '', 'name,value');
         $settings = $DB->get_records_menu('plagiarism_turnitin_config', array('cm' => $cmid), '', 'name,value');
 
         // Enforce site wide config locking.

--- a/lib.php
+++ b/lib.php
@@ -1721,7 +1721,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     }
 
                     // Don't add the submission to the request if module settings mean we will not get a report back.
-                    if ($plagiarismsettings['plagiarism_compare_student_papers'] == 0 &&
+                    if (array_key_exists('plagiarism_compare_student_papers', $plagiarismsettings) &&
+                        $plagiarismsettings['plagiarism_compare_student_papers'] == 0 &&
                         $plagiarismsettings['plagiarism_compare_internet'] == 0 &&
                         $plagiarismsettings['plagiarism_compare_journals'] == 0 &&
                         $plagiarismsettings['plagiarism_compare_institution'] == 0) {

--- a/settings.php
+++ b/settings.php
@@ -86,7 +86,7 @@ if (!empty($action)) {
 
             foreach ($settingsfields as $field) {
                 $defaultfield = new object();
-                $defaultfield->cm = 0;
+                $defaultfield->cm = null;
                 $defaultfield->name = $field;
                 if ($field == 'plagiarism_locked_message'){
                     $defaultfield->value = optional_param($field, '', PARAM_TEXT);
@@ -96,7 +96,7 @@ if (!empty($action)) {
 
                 if (isset($plugindefaults[$field])) {
                     $defaultfield->id = $DB->get_field('plagiarism_turnitin_config', 'id',
-                                                (array('cm' => 0, 'name' => $field)));
+                                                (array('cm' => null, 'name' => $field)));
                     if (!$DB->update_record('plagiarism_turnitin_config', $defaultfield)) {
                         turnitintooltwo_print_error('defaultupdateerror', 'turnitintooltwo', null, null, __FILE__, __LINE__);
                     }


### PR DESCRIPTION
when DB foreign key enable we can't use 0 as index we need to use null instead.
In cron run sometimes there is error about missing index.