### PR TITLE
Check for $CFG->version before using

### DIFF
--- a/version.php
+++ b/version.php
@@ -12,7 +12,7 @@ $plugin->component = 'plagiarism_turnitin';
 $plugin->maturity  = MATURITY_STABLE;
 
 global $CFG;
-if ($CFG->version > 2014051200) {
+if (!empty($CFG->version) && $CFG->version > 2014051200) {
 	$plugin->cron = 0;
 }else{
 	$plugin->cron = 300;


### PR DESCRIPTION
The test for the Moodle version number in version.php causes a PHP notice to be thrown when $CFG->version is not set (e.g. when running unit tests):

> Notice: Undefined property: stdClass::$version in F:\htdocs\pixie-beta\plagiarism\turnitin\version.php on line 15

 It would be good to test for this property's existence before using it.