### PR TITLE
Wrap colorbox in a click handler for EULA link

### DIFF
--- a/jquery/turnitin_module.js
+++ b/jquery/turnitin_module.js
@@ -133,24 +133,27 @@ jQuery(document).ready(function($) {
 
     // Open an iframe light box containing the EULA View
     if ($('.pp_turnitin_eula_link').length > 0) {
-        $('.pp_turnitin_eula_link').colorbox({
-            iframe:true, width:"766px", height:"596px", opacity: "0.7", className: "eula_view", scrolling: "false",
-            onLoad: function() { getLoadingGif(); },
-            onComplete: function() {
-                $(window).on("message", function(ev) {
-                    var message = typeof ev.data === 'undefined' ? ev.originalEvent.data : ev.data;
+        $(document).on('click', '.pp_turnitin_eula_link', function(e) {
+            e.preventDefault();
+            $.colorbox({
+                iframe:true, href:this.href, width:"766px", height:"596px", opacity: "0.7", className: "eula_view", scrolling: "false",
+                onOpen: function() { getLoadingGif(); },
+                onComplete: function() {
+                    $(window).on("message", function(ev) {
+                        var message = typeof ev.data === 'undefined' ? ev.originalEvent.data : ev.data;
 
-                    $.ajax({
-                        type: "POST",
-                        url: M.cfg.wwwroot +"/plagiarism/turnitin/ajax.php",
-                        dataType: "json",
-                        data: {action: "actionuseragreement", message: message, sesskey: M.cfg.sesskey},
-                        success: function(data) { window.location.reload(); },
-                        error: function(data) { window.location.reload(); }
+                        $.ajax({
+                            type: "POST",
+                            url: M.cfg.wwwroot +"/plagiarism/turnitin/ajax.php",
+                            dataType: "json",
+                            data: {action: "actionuseragreement", message: message, sesskey: M.cfg.sesskey},
+                            success: function(data) { window.location.reload(); },
+                            error: function(data) { window.location.reload(); }
+                        });
                     });
-                });
-            },
-            onCleanup: function() { hideLoadingGif(); }
+                },
+                onCleanup: function() { hideLoadingGif(); }
+            });
         });
     }
 


### PR DESCRIPTION
When calling colorbox directly on the EULA link, it doesn't always open
in an iframe if the student has previously declined the EULA - often it
will load the form inline, resulting in the browser being redirected to
the EULA on a blank page on the TII site instead of displaying on top of
the Moodle page.  This means that the user gets "stuck" on the TII site -
they're not returned to Moodle after either accepting or declining.

This fixes issue #89. 