### PR TITLE
Add check for file contents

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2175,6 +2175,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                             turnitintooltwo_activitylog('File not found: '.$pathnamehash, 'PP_NO_FILE');
                             $result = true;
                             continue;
+                        } else {
+                            try {
+                                $file->get_content();
+                            } catch (Exception $e){
+                                turnitintooltwo_activitylog('File content not found: '.$pathnamehash, 'PP_NO_FILE');
+                                mtrace($e);
+                                mtrace('File content not found. pathnamehash: '.$pathnamehash);
+                                $result = true;
+                                continue;
+                            }
                         }
 
                         if ($file->get_filename() === '.') {


### PR DESCRIPTION
Had a system outage and the event handler was trying to fetch the contents of a non existent file. Uncaught exception halted any submissions from being processed. This adds a check that functions similarly to the existing file check above it.