### PR TITLE
Issue #179 - PHPUnit test failing with Moodle 31

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -316,6 +316,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         foreach ($supportedmods as $supportedmod) {
             $module = $DB->get_record('modules', array('name' => $supportedmod));
+            if ($module === false) {
+                continue;
+            }
 
             // Get all the course modules that have Turnitin enabled
             $sql = "SELECT cm.id

--- a/tests/turnitin_test.php
+++ b/tests/turnitin_test.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plagiarism Turnitin tests.
+ *
+ * @package    plagiarism_turnitin
+ * @copyright  2016 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+use core_competency\course_competency;
+
+/**
+ * Plagiarism Turnitin tests.
+ *
+ * @package    plagiarism_turnitin
+ * @copyright  2016 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class plagiarism_turnitin_testcase extends advanced_testcase {
+    /**
+     * Isolates a problem found running core tests in Moodle 31.
+     */
+    public function test_problem_moodle31_coretests() {
+        $this->resetAfterTest();
+
+        $c1 = $this->getDataGenerator()->create_course();
+
+        reset_course_userdata((object)['id' => $c1->id, 'reset_competency_ratings' => true]);
+    }
+}


### PR DESCRIPTION
Hi, pulling request again based on 'develop'.

When I run core Moodle 31 PHPUnit tests, one of them fails if I have this plugin installed.

I've isolated the problem in the lib, where it finds the supported modules based on the file (classes/modules) system then tries to fetch the ID in the database.

Because it cannot find the module in the DB (returns false), if fails when trying go get the $module->id.

I wrote a test reproducing the behaviour and a proposed solution; however, someone who has better understanding of this plugin could propose a better solution.

Cheers,

Daniel
