### PR TITLE
Quick fix for Rubric close button not working. Only fixes the top-rig…

### DIFF
--- a/jquery/turnitin_module.js
+++ b/jquery/turnitin_module.js
@@ -3,7 +3,11 @@
  * and open the template in the editor.
  */
 
+var plagiarism_turnitin_jquery = null;
+
 jQuery(document).ready(function($) {
+    plagiarism_turnitin_jquery = $;
+
     $(document).on('mouseover', '.tii_links_container .tii_tooltip', function() {
         $(this).tooltipster({ multiple: true });
         return false;
@@ -168,7 +172,7 @@ jQuery(document).ready(function($) {
     }
 
     function lightBoxCloseButton(closeBtnText) {
-        $('body').append('<div id="tii_close_bar"><a href="#" onclick="$.colorbox.close(); return false;">' + M.str.plagiarism_turnitin.closebutton + '</a></div>');
+        $('body').append('<div id="tii_close_bar"><a href="#" onclick="plagiarism_turnitin_jquery.colorbox.close(); return false;">' + M.str.plagiarism_turnitin.closebutton + '</a></div>');
     }
 
     function getLoadingGif() {


### PR DESCRIPTION
Give you have an assignment with a rubric

When you are attempting to submit the assignment, I click on "View the Rubric used for marking" then I click on close (either in the top-right or in the modal form)

Then I see the following error:

view.php?id=21&action=editsubmission:1 Uncaught TypeError: Cannot read property 'colorbox' of undefined(…)onclick @ view.php?id=21&action=editsubmission:1

Example of URL:
http://moodle.test/mod/assign/view.php?id=21&action=editsubmission

Notes: Clicking outside the Modal form still works.

It seems like a jQuery error, it cannot find the '$' in <a href="#" onclick="$.colorbox.close(); return false;">Close</a>
