### PR TITLE
Moodle Behat tests fail when a module isn't installed 

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -318,6 +318,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         foreach ($supportedmods as $supportedmod) {
             $module = $DB->get_record('modules', array('name' => $supportedmod));
 
+            if (!$module){
+               #Skip module that isn't installed.
+               continue;
+            }
+
             // Get all the course modules that have Turnitin enabled
             $sql = "SELECT cm.id
                     FROM {course_modules} cm


### PR DESCRIPTION
Moodle Behat tests fail when a module isn't installed but lib.php calls $module->id

Error message from behat:

PHP debug message/s found:
Notice: Trying to get property of non-object in /home/oit-moodle/3.0/docs/plagiarism/turnitin/lib.php on line 328

Failing Moodle Behat feature files:

mod/chat/tests/behat/chat_course_reset.feature
mod/lesson/tests/behat/lesson_course_reset.feature
mod/quiz/tests/behat/quiz_reset.feature