### PR TITLE
(develop) Fixes Issue #194 - Turnitin slows mod/forum/post.php even when TII is not enabled for that mod.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -390,9 +390,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         global $DB, $OUTPUT, $USER, $PAGE, $CFG;
 
         static $tiiconnection;
-        if (empty($tiiconnection)) {
-            $tiiconnection = $this->test_turnitin_connection();
-        }
 
         $config = turnitintooltwo_admin_config();
         $output = '';
@@ -421,6 +418,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
 
         // Show EULA if necessary and we have a connection to Turnitin.
+        if (empty($tiiconnection)) {
+            $tiiconnection = $this->test_turnitin_connection();
+        }
         if ($tiiconnection) {
             $coursedata = $this->get_course_data($cm->id, $cm->course);
 


### PR DESCRIPTION
A call to mod/forum/post.php may trigger a print_disclosure() for all plagiarism plugins.

If the TII server is slow (or there is a timeout), the page becomes very slow even when turn it in is not needed.

This fix: print_disclosure() now only checks the connection when it is needed.
