### PR TITLE
Fix error code for 40mb file.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -974,6 +974,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                         if ($errorcode == 0 && $submissiontype == 'file') {
                             if ($file->get_filesize() > TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE) {
                                 $errorcode = 2;
+                                $plagiarismfile->errorcode = 2;
                             }
                         }
 


### PR DESCRIPTION
The error message language string was not being set for files greater than 40mb.