### PR TITLE
Ignore missing course modules

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2540,6 +2540,12 @@ function plagiarism_turnitin_send_queued_submissions() {
         // Get various settings that we need.
         $errorcode = 0;
         $cm = get_coursemodule_from_id('', $queueditem->cm);
+
+        // Ignore course modules that no longer exist.
+        if (empty($cm)) {
+            continue;
+        }
+
         $settings = $pluginturnitin->get_settings($cm->id);
         $moduledata = $DB->get_record($cm->modname, array('id' => $cm->instance));
 


### PR DESCRIPTION
Hi, here's a patch to add a bit of defensive programming to prevent missing course modules crashing the send_submissions task. I know the plugin should remove files when a course module is deleted, but we've seen a couple of instances where there are still files for a deleted module (not sure why). In line with the rest of Moodle it's a good idea not to assume that a cm exists, even when it "should".