### PR TITLE
Potential fix for #250

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -207,6 +207,13 @@ switch ($action) {
 
         // Update the user using the above object.
         $DB->update_record('turnitintooltwo_users', $eulauser, $bulk = false);
+
+        //Also reset their submissions ( ? ) University of Bath
+        $faileditems = $DB->get_records_select('plagiarism_turnitin_files','userid = ? AND errorcode = ?',array($USER->id,3));
+        foreach ($faileditems as $fail_submission){
+            turnitintooltwo_activitylog("Resetting user's submission as they have now accepted the EULA (CM: ".$cm->id.", User: ".$USER->id.")","PP_EULA_ACCEPTANCE");
+            $pluginturnitin->save_submission($cm,$USER->id,$fail_submission->id,$fail_submission->identifier,null,null,$USER->id,$fail_submission->itemid,$fail_submission->submissiontype,$fail_submission->attempt);
+        }
         break;
 
     case "resubmit_event":

--- a/jquery/turnitin_module.js
+++ b/jquery/turnitin_module.js
@@ -131,6 +131,13 @@ jQuery(document).ready(function($) {
     if ($('.pp_turnitin_eula_link').length > 0) {
         $(document).on('click', '.pp_turnitin_eula_link', function(e) {
             e.preventDefault();
+            var href = this.href;
+            $.urlParam = function(name,href){
+                var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(href);
+                return results[1] || 0;
+            }
+            var cmid = $.urlParam('cmid',href); // cmid
+            console.log(cmid);
             $.colorbox({
                 iframe:true, href:this.href, width:"766px", height:"596px", opacity: "0.7", className: "eula_view", scrolling: "false",
                 onOpen: function() { getLoadingGif(); },
@@ -142,7 +149,7 @@ jQuery(document).ready(function($) {
                             type: "POST",
                             url: M.cfg.wwwroot + "/plagiarism/turnitin/ajax.php",
                             dataType: "json",
-                            data: {action: "actionuseragreement", message: message, sesskey: M.cfg.sesskey},
+                            data: {action: "actionuseragreement", message: message, sesskey: M.cfg.sesskey, cmid:cmid},
                             success: function(data) { window.location.reload(); },
                             error: function(data) { window.location.reload(); }
                         });

--- a/jquery/turnitin_module_post29.js
+++ b/jquery/turnitin_module_post29.js
@@ -131,6 +131,13 @@ require(['jquery'], function($) {
     if ($('.pp_turnitin_eula_link').length > 0) {
         $(document).on('click', '.pp_turnitin_eula_link', function(e) {
             e.preventDefault();
+            var href = this.href;
+            $.urlParam = function(name,href){
+                var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(href);
+                return results[1] || 0;
+            }
+            var cmid = $.urlParam('cmid',href); // cmid
+            console.log(cmid);
             $.colorbox({
                 iframe:true, href:this.href, width:"766px", height:"596px", opacity: "0.7", className: "eula_view", scrolling: "false",
                 onOpen: function() { getLoadingGif(); },

--- a/jquery/turnitin_module_post29.js
+++ b/jquery/turnitin_module_post29.js
@@ -149,7 +149,7 @@ require(['jquery'], function($) {
                             type: "POST",
                             url: M.cfg.wwwroot + "/plagiarism/turnitin/ajax.php",
                             dataType: "json",
-                            data: {action: "actionuseragreement", message: message, sesskey: M.cfg.sesskey},
+                            data: {action: "actionuseragreement", message: message, sesskey: M.cfg.sesskey,cmid:cmid},
                             success: function(data) { window.location.reload(); },
                             error: function(data) { window.location.reload(); }
                         });

--- a/lib.php
+++ b/lib.php
@@ -1074,6 +1074,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                             // We need to check for security that the user is actually on the course.
                             if ($moduleobject->user_enrolled_on_course($context, $linkarray["userid"])) {
                                 $user = new turnitintooltwo_user($linkarray["userid"], "Learner");
+                                var_dump($user);
                                 if ($user->useragreementaccepted != 1) {
                                     $erroricon = html_writer::tag('div', $OUTPUT->pix_icon('doc-x-grey', get_string('errorcode3', 'plagiarism_turnitin'),
                                                                             'plagiarism_turnitin'),

--- a/lib.php
+++ b/lib.php
@@ -2095,6 +2095,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     // Don't submit if submission hasn't changed.
                     if (in_array($previoussubmission->statuscode, array("success", "error"))
                             && $timemodified <= $previoussubmission->lastmodified) {
+
+                        //Check that if the user has retrospectively accepted EULA  - university of Bath
+                        $user = new turnitintooltwo_user($previoussubmissions->userid, 'Learner', 'false', 'cron', 'true');
+                        if($user->get_accepted_user_agreement()){
+                            //Looks like the user has accepted the agreement
+                            // Reset their submission
+                            $submissionid = $previoussubmission->id;
+                            mtrace("Resetting user's submission as they have accepted the EULA");
+                            $this->reset_tii_submission($cm, $author, $identifier, $previoussubmission, $submissiontype);
+                        }
                         return true;
                     } else if ($settings["plagiarism_report_gen"] > 0) {
                         // Replace if Turnitin assignment allows resubmissions or create if we have no Turnitin id stored.

--- a/lib.php
+++ b/lib.php
@@ -2096,13 +2096,12 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     if (in_array($previoussubmission->statuscode, array("success", "error"))
                             && $timemodified <= $previoussubmission->lastmodified) {
 
-                        //Check that if the user has retrospectively accepted EULA  - university of Bath
+                        //Check that if the user has retrospectively accepted EULA  - University of Bath
                         $user = new turnitintooltwo_user($previoussubmissions->userid, 'Learner', 'false', 'cron', 'true');
                         if($user->get_accepted_user_agreement()){
                             //Looks like the user has accepted the agreement
                             // Reset their submission
-                            $submissionid = $previoussubmission->id;
-                            mtrace("Resetting user's submission as they have accepted the EULA");
+                            turnitintooltwo_activitylog("Resetting user's submission as they have now accepted the EULA (CM: ".$cm->id.", User: ".$previoussubmissions->userid.")","PP_EULA_ACCEPTANCE");
                             $this->reset_tii_submission($cm, $author, $identifier, $previoussubmission, $submissiontype);
                         }
                         return true;

--- a/lib.php
+++ b/lib.php
@@ -2097,13 +2097,13 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                             && $timemodified <= $previoussubmission->lastmodified) {
 
                         //Check that if the user has retrospectively accepted EULA  - University of Bath
-                        $user = new turnitintooltwo_user($previoussubmissions->userid, 'Learner', 'false', 'cron', 'true');
-                        if($user->get_accepted_user_agreement()){
+                        //$user = new turnitintooltwo_user($previoussubmissions->userid, 'Learner', 'false', 'cron', 'true');
+                        /*if($user->get_accepted_user_agreement()){
                             //Looks like the user has accepted the agreement
                             // Reset their submission
                             turnitintooltwo_activitylog("Resetting user's submission as they have now accepted the EULA (CM: ".$cm->id.", User: ".$previoussubmissions->userid.")","PP_EULA_ACCEPTANCE");
                             $this->reset_tii_submission($cm, $author, $identifier, $previoussubmission, $submissiontype);
-                        }
+                        }*/
                         return true;
                     } else if ($settings["plagiarism_report_gen"] > 0) {
                         // Replace if Turnitin assignment allows resubmissions or create if we have no Turnitin id stored.


### PR DESCRIPTION
Hi John,
I believe this is what should do the trick. We are making sure that if a student ignores the EULA the first time around but accepts it retrospectively (for a separate assignment for example) then their previous submissions should be queued again and sent to turnitin. 

PS  - I'm sure there is a better way to get the cmid to pass to ajax.php when a user accepts the EULA by clicking on 'I agree' -  [code](https://github.com/hitteshahuja/moodle-plagiarism_turnitin/blob/addff721330a85d665d3a573f455f8c4e3e9b0a3/jquery/turnitin_module.js#L135 )