### PR TITLE
Checking for moodle version < 2.6 before loading jQuery 1.8.2

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -506,8 +506,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     public function load_page_components() {
         global $CFG, $PAGE;
 
-        $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/jquery-1.8.2.min.js');
-        $PAGE->requires->js($jsurl);
+        if ($CFG->branch <= 25) {
+            $jsurl = new moodle_url($CFG->wwwroot.'/plagiarism/turnitin/jquery/jquery-1.8.2.min.js');
+            $PAGE->requires->js($jsurl);
+        }
+        else {
+            $PAGE->requires->jquery();
+        }
+
         $jsurl = new moodle_url($CFG->wwwroot.'/mod/turnitintooltwo/jquery/turnitintooltwo.js');
         $PAGE->requires->js($jsurl);
         if ($CFG->branch > 29) {


### PR DESCRIPTION
When `load_page_components()` is called jQuery 1.8.2 is loaded despite the fact that since version 2.6 Moodle comes with - a more recent version of - jQuery already loaded.
This leads to unwanted side effects - like some elements not acting as wanted or at all etc - when using a theme based on bootstrap - which requires at least jQuery 1.9.1 (while the current version pre-loaded by Moodle seems to be 3.1.0 at the time of writing!)
I therefore ask to check for the Moodle version before loading that rather outdated version of jQuery while using the already loaded version by Moodle otherwise.