### PR TITLE
Keep delete_tii_submission public till its no longer called externally

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2493,7 +2493,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     /**
      * Delete a submission from Turnitin
      */
-    private function delete_tii_submission($cm, $submissionid, $userid) {
+    public function delete_tii_submission($cm, $submissionid, $userid) {
         global $DB;
         $user = $DB->get_record('user', array('id' => $userid));
 


### PR DESCRIPTION
This function is used from outside the class its in during cron, so we
can't have it private till thats fixed up.

Without this change, a submission triggering that call can cause Moodle
cron to get blocked.