### PR TITLE
Handle resubmissions correctly if only 1 file is allowed to be submitted

### DIFF
--- a/classes/modules/turnitin_assign.class.php
+++ b/classes/modules/turnitin_assign.class.php
@@ -62,6 +62,30 @@ class turnitin_assign {
         return (empty($onlinetextdata->onlinetext)) ? '' : $onlinetextdata->onlinetext;
     }
 
+
+	/**
+	 * Check if resubmissions in a Turnitin sense are allowed to an assignment.
+	 *
+	 * @param $assignid
+	 */
+	public function is_resubmission_allowed($assignid, $reportgenspeed, $submissiontype, $attemptreopenmethod) {
+		global $DB;
+
+		// Get the maximum number of file submissions allowed.
+		$params = array('assignment' => $assignid,
+			'subtype' => 'assignsubmission',
+			'plugin' => 'file',
+			'name' => 'maxfilesubmissions');
+
+		$maxfilesubmissions = 0;
+		if ($result = $DB->get_record('assign_plugin_config', $params, 'value')) {
+			$maxfilesubmissions = $result->value;
+		}
+
+		return ($reportgenspeed > 0 && $attemptreopenmethod == ASSIGN_ATTEMPT_REOPEN_METHOD_NONE
+			&& ($submissiontype == 'text_content' || $maxfilesubmissions == 1));
+	}
+
     public function get_onlinetext($userid, $cm) {
         global $DB;
 

--- a/lib.php
+++ b/lib.php
@@ -714,7 +714,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             }
 
             // Show the EULA for a student if necessary.
-            if ($linkarray["userid"] == $USER->id && empty($plagiarismfile->externalid)) {
+            if ($linkarray["userid"] == $USER->id) {
                 $eula = "";
 
                 static $userid;
@@ -1831,39 +1831,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     }
 
     /**
-     * Check whether we need to submit the file to Turnitin. If the file has not previously been submitted then submit it.
-     * If text content gets this far then it needs to be submitted
-     *
-     * @param object $user the user who the submission is for
-     * @param string $pathnamehash to identify the file to be submitted
-     */
-    public function check_if_submitting($cm, $userid, $pathnamehash, $submissiontype) {
-        global $DB;
-
-        if ($submissiontype == 'text_content' || $submissiontype == 'forum_post') {
-            return true;
-        } else if ($previoussubmissions = $DB->get_records_select('plagiarism_turnitin_files',
-                                                    " cm = ? AND userid = ? AND identifier = ? ",
-                                                array($cm->id, $userid, $pathnamehash), 'id DESC',
-                                                    'id, cm, externalid, identifier, statuscode, lastmodified', 0, 1)) {
-
-            // Get the file data to check date modified.
-            $fs = get_file_storage();
-            $file = $fs->get_file_by_hash($pathnamehash);
-
-            $currentsubmission = current($previoussubmissions);
-            if ($currentsubmission->identifier == $pathnamehash && $currentsubmission->statuscode == "success"
-                && $file->get_timemodified() <= $currentsubmission->lastmodified) {
-                return false;
-            } else {
-                return true;
-            }
-        } else {
-            return true;
-        }
-    }
-
-    /**
      * Call functions to be run by cron
      */
     public function cron() {
@@ -2121,16 +2088,40 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         return $coursedata;
     }
 
-    /**
-     * Queue submissions to send to Turnitin
-     *
-     *
-     */
-    public function queue_submission_to_turnitin($cm, $author, $submitter, $identifier, $submissiontype, $itemid = 0) {
+
+	/**
+	 * Queue submissions to send to Turnitin
+	 *
+	 * @param $cm
+	 * @param $author
+	 * @param $submitter
+	 * @param $identifier
+	 * @param $submissiontype
+	 * @param int $itemid
+	 * @return bool
+	 */
+	public function queue_submission_to_turnitin($cm, $author, $submitter, $identifier, $submissiontype, $itemid = 0) {
         global $CFG, $DB, $turnitinacceptedfiles;
         $errorcode = 0;
         $attempt = 0;
+        $tiisubmissionid = null;
         $settings = $this->get_settings($cm->id);
+
+		// Create module object.
+		$moduleclass = "turnitin_".$cm->modname;
+		$moduleobject = new $moduleclass;
+
+		// Get module data.
+		$moduledata = $DB->get_record($cm->modname, array('id' => $cm->instance));
+		$moduledata->resubmission_allowed = false;
+		if ($cm->modname == 'assign') {
+			$moduledata->resubmission_allowed = $moduleobject->is_resubmission_allowed(
+				$cm->instance,
+				$settings["plagiarism_report_gen"],
+				$submissiontype,
+				$moduledata->attemptreopenmethod
+			);
+		}
 
         // Work out submission method.
         // If this file has successfully submitted in the past then break, text content is to be submitted.
@@ -2168,21 +2159,23 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $submissionfields = 'id, cm, externalid, identifier, statuscode, lastmodified, attempt';
                 $typefield = ($CFG->dbtype == "oci") ? " to_char(submissiontype) " : " submissiontype ";
 
-                // Double check there is only one submission.
+                // Check if this content/file has been submitted previously.
                 $previoussubmissions = $DB->get_records_select('plagiarism_turnitin_files',
                                                     " cm = ? AND userid = ? AND ".$typefield." = ? AND identifier = ? ",
                                                 array($cm->id, $author, $submissiontype, $identifier),
                                                     'id', $submissionfields);
                 $previoussubmission = end($previoussubmissions);
+
                 if ($previoussubmission) {
                     // Don't submit if submission hasn't changed.
                     if (in_array($previoussubmission->statuscode, array("success", "error"))
                             && $timemodified <= $previoussubmission->lastmodified) {
                         return true;
-                    } else if ($settings["plagiarism_report_gen"] > 0) {
-                        // Replace if Turnitin assignment allows resubmissions or create if we have no Turnitin id stored.
+                    } else if ($moduledata->resubmission_allowed) {
+						// Replace submission in the specific circumstance where Turnitin can accomodate resubmissions.
                         $submissionid = $previoussubmission->id;
                         $this->reset_tii_submission($cm, $author, $identifier, $previoussubmission, $submissiontype);
+						$tiisubmissionid = $previoussubmission->externalid;
                     } else {
                         if ($previoussubmission->statuscode != "success") {
                             $submissionid = $previoussubmission->id;
@@ -2193,24 +2186,29 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     }
                     $attempt = $previoussubmission->attempt;
                 } else {
-                    // Check if there is previous submission of text content which we will replace.
+                    // Check if there is previous submission of different content which we may be able to replace.
                     $typefield = ($CFG->dbtype == "oci") ? " to_char(submissiontype) " : " submissiontype ";
-                    if ($submissiontype == 'text_content' &&
-                            $previoussubmission = $DB->get_record_select('plagiarism_turnitin_files',
+                    if ($previoussubmission = $DB->get_record_select('plagiarism_turnitin_files',
                                                     " cm = ? AND userid = ? AND ".$typefield." = ? ",
-                                                array($cm->id, $author, 'text_content'),
-                                                    'id, cm, externalid, identifier, statuscode, lastmodified, attempt', 0, 1)) {
+                                                array($cm->id, $author, $submissiontype),
+                                                    'id, cm, externalid, identifier, statuscode, lastmodified, attempt')) {
 
-                        $submissionid = $previoussubmission->id;
-                        $attempt = $previoussubmission->attempt;
+						$submissionid = $previoussubmission->id;
+						$attempt = $previoussubmission->attempt;
+						// Delete old text content submissions from Turnitin if resubmissions aren't allowed.
+						if ($submissiontype == 'text_content' && $settings["plagiarism_report_gen"] == 0 && !is_null($previoussubmission->externalid)) {
+							$this->delete_tii_submission($cm, $previoussubmission->externalid, $author);
+						}
 
-                        // Delete old text content submissions from Turnitin if not replacing.
-                        if ($settings["plagiarism_report_gen"] == 0 && !is_null($previoussubmission->externalid)) {
-                            $this->delete_tii_submission($cm, $previoussubmission->externalid, $author);
-                        }
+						// Replace submission in the specific circumstance where Turnitin can accomodate resubmissions.
+						if ($moduledata->resubmission_allowed || $submissiontype == 'text_content') {
+							$this->reset_tii_submission($cm, $author, $identifier, $previoussubmission, $submissiontype);
+							$tiisubmissionid = $previoussubmission->externalid;
+						} else {
+							$submissionid = $this->create_new_tii_submission($cm, $author, $identifier, $submissiontype);
+						}
 
-                        $this->reset_tii_submission($cm, $author, $identifier, $previoussubmission, $submissiontype);
-                    } else {
+					} else {
                         $submissionid = $this->create_new_tii_submission($cm, $author, $identifier, $submissiontype);
                     }
                 }
@@ -2229,6 +2227,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     } else {
                         $submissionid = $previoussubmission->id;
                         $attempt = $previoussubmission->attempt;
+						$tiisubmissionid = $previoussubmission->externalid;
                         $this->reset_tii_submission($cm, $author, $identifier, $previoussubmission, $submissiontype);
                     }
                 } else {
@@ -2256,8 +2255,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Save submission as queued or errored if we have an errorcode.
         $statuscode = ($errorcode != 0) ? 'error' : 'queued';
-        return $this->save_submission($cm, $author, $submissionid, $identifier, $statuscode, null, $submitter, $itemid,
-                        $submissiontype, $attempt, $errorcode, null);
+        return $this->save_submission($cm, $author, $submissionid, $identifier, $statuscode, $tiisubmissionid, $submitter, $itemid,
+                        $submissiontype, $attempt, $errorcode);
     }
 
     /**
@@ -2393,13 +2392,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     continue;
                 }
 
-                if ($this->check_if_submitting($cm, $author, $pathnamehash, 'file')) {
-                    $result = $result && $this->queue_submission_to_turnitin(
+				$result = $result && $this->queue_submission_to_turnitin(
                                                 $cm, $author, $submitter, $pathnamehash, 'file',
-                                                $eventdata['objectid'], '');
-                } else {
-                    $result = $result && true;
-                }
+                                                $eventdata['objectid']);
             }
         }
 
@@ -2631,16 +2626,12 @@ function plagiarism_turnitin_send_queued_submissions() {
     // Submit each file individually to Turnitin.
     foreach ($queueditems as $queueditem) {
 
-        // Get various settings that we need.
-        $errorcode = 0;
-
-        $cm = get_coursemodule_from_id('', $queueditem->cm);
-
         // Don't proceed if we can not find a cm.
+		$cm = get_coursemodule_from_id('', $queueditem->cm);
         if (empty($cm)) {
             $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 12);
 
-            // Output a message in the cron for successfull submission to Turnitin.
+            // Output a message in the cron for failed submission to Turnitin.
             $outputvars = new stdClass();
             $outputvars->id = $queueditem->id;
             $outputvars->cm = $queueditem->cm;
@@ -2650,8 +2641,24 @@ function plagiarism_turnitin_send_queued_submissions() {
             continue;
         }
 
+		// Get various settings that we need.
+		$errorcode = 0;
         $settings = $pluginturnitin->get_settings($cm->id);
+
+		// Create module object.
+		$moduleclass = "turnitin_".$cm->modname;
+		$moduleobject = new $moduleclass;
+
+		// Get module data.
         $moduledata = $DB->get_record($cm->modname, array('id' => $cm->instance));
+		$moduledata->resubmission_allowed = false;
+		if ($cm->modname == 'assign') {
+			$moduledata->resubmission_allowed = $moduleobject->is_resubmission_allowed(
+				$cm->instance, $settings["plagiarism_report_gen"],
+				$queueditem->submissiontype,
+				$moduledata->attemptreopenmethod
+			);
+		}
 
         // Get course data.
         $coursedata = $pluginturnitin->get_course_data($cm->id, $cm->course, 'cron');
@@ -2768,10 +2775,12 @@ function plagiarism_turnitin_send_queued_submissions() {
                 if (is_null($queueditem->externalid)) {
                     $apimethod = "createSubmission";
                 } else {
-                    $apimethod = ($settings["plagiarism_report_gen"] == 0) ? "createSubmission" : "replaceSubmission";
+
+                    $apimethod = ($moduledata->resubmission_allowed) ? "replaceSubmission" : "createSubmission";
+
                     // Delete old text content submissions from Turnitin if not replacing.
                     if ($settings["plagiarism_report_gen"] == 0 && $queueditem->submissiontype == 'text_content') {
-                        $pluginturnitin->delete_tii_submission($cm, $queueditem->externalid, $queueditem->userid);
+						$pluginturnitin->delete_tii_submission($cm, $queueditem->externalid, $queueditem->userid);
                     }
                 }
 

--- a/tests/modules/turnitin_assign_test.php
+++ b/tests/modules/turnitin_assign_test.php
@@ -1,0 +1,114 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for (some of) mod/turnitintooltwo/view.php.
+ *
+ * @package    plagiarism_turnitin
+ * @copyright  2017 Turnitin
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/plagiarism/turnitin/lib.php');
+require_once($CFG->dirroot . '/mod/assign/externallib.php');
+
+/**
+ * Tests for API comms class
+ *
+ * @package turnitin
+ */
+class plagiarism_turnitin_lib_testcase extends advanced_testcase {
+
+	/**
+	 * Create a course and assignment module instance
+	 */
+	public function setup() {
+		global $DB;
+
+		$this->course = $this->getDataGenerator()->create_course();
+		$params = array(
+			'course' => $this->course->id,
+			'name' => 'assignment',
+			'assignsubmission_file_enabled' => 1,
+			'assignsubmission_file_maxfiles' => 1,
+			'assignsubmission_file_maxsizebytes' => 10
+		);
+
+		$this->assign = $this->getDataGenerator()->create_module('assign', $params);
+	}
+
+	/**
+	 * Test to check whether resubmissions are allowed.
+	 */
+	public function test_check_is_resubmission_allowed() {
+		global $DB, $CFG;
+
+		$this->resetAfterTest(true);
+
+		// Create module object.
+		$moduleobject = new turnitin_assign();
+
+		$resubmissionallowed = $moduleobject->is_resubmission_allowed($this->assign->id, 1, 'file', ASSIGN_ATTEMPT_REOPEN_METHOD_NONE);
+		$this->assertTrue($resubmissionallowed);
+
+		$resubmissionallowed = $moduleobject->is_resubmission_allowed($this->assign->id, 1, 'text_content', ASSIGN_ATTEMPT_REOPEN_METHOD_NONE);
+		$this->assertTrue($resubmissionallowed);
+
+		$resubmissionallowed = $moduleobject->is_resubmission_allowed($this->assign->id, 1, 'text_content', ASSIGN_ATTEMPT_REOPEN_METHOD_MANUAL);
+		$this->assertFalse($resubmissionallowed);
+
+		$resubmissionallowed = $moduleobject->is_resubmission_allowed($this->assign->id, 0, 'file', ASSIGN_ATTEMPT_REOPEN_METHOD_NONE);
+		$this->assertFalse($resubmissionallowed);
+
+		$resubmissionallowed = $moduleobject->is_resubmission_allowed($this->assign->id, 0, 'text_content', ASSIGN_ATTEMPT_REOPEN_METHOD_NONE);
+		$this->assertFalse($resubmissionallowed);
+
+		$resubmissionallowed = $moduleobject->is_resubmission_allowed($this->assign->id, 1, 'file', ASSIGN_ATTEMPT_REOPEN_METHOD_MANUAL);
+		$this->assertFalse($resubmissionallowed);
+	}
+
+
+	/**
+	 * Test that resubmissions are not allowed for files if the maximum files in a submission is more than 1.
+	 */
+	public function test_check_is_resubmission_allowed_maxfiles_above_threshold() {
+		global $DB, $CFG;
+
+		$this->resetAfterTest(true);
+
+		$params = array(
+			'course' => $this->course->id,
+			'name' => 'assignment',
+			'assignsubmission_file_enabled' => 1,
+			'assignsubmission_file_maxfiles' => 2,
+			'assignsubmission_file_maxsizebytes' => 10
+		);
+
+		$assign = $this->getDataGenerator()->create_module('assign', $params);
+
+		// Create module object.
+		$moduleobject = new turnitin_assign();
+
+		$resubmissionallowed = $moduleobject->is_resubmission_allowed($assign->id, 1, 'file', ASSIGN_ATTEMPT_REOPEN_METHOD_NONE);
+		$this->assertFalse($resubmissionallowed);
+
+		$resubmissionallowed = $moduleobject->is_resubmission_allowed($assign->id, 1, 'text_content', ASSIGN_ATTEMPT_REOPEN_METHOD_NONE);
+		$this->assertTrue($resubmissionallowed);
+	}
+}


### PR DESCRIPTION
Only resubmits to Turnitin if:
- Max files is 1 for file submissions
- Attempts are off
- Report Gen Speed is > 0

Please ignore the indentation errors in lib.php (IDE changes), I'll fix these in a separate PR once this has passed Code Review.