### PR TITLE
Moodle 35 fixes

### DIFF
--- a/classes/digitalreceipt/pp_receipt_message.php
+++ b/classes/digitalreceipt/pp_receipt_message.php
@@ -31,11 +31,17 @@ class pp_receipt_message {
      * @param string $message
      * @return void
      */
-    public function send_message($userid, $message) {
+    public function send_message($userid, $message, $courseid) {
+        global $CFG;
 
         $subject = get_string('digital_receipt_subject', 'plagiarism_turnitin');
 
-        $eventdata = new stdClass();
+        // Pre 2.9 does not have \core\message\message()
+        if ($CFG->branch >= 29) {
+            $eventdata = new \core\message\message();
+        } else {
+            $eventdata = new stdClass();
+        }
         $eventdata->component         = 'plagiarism_turnitin'; // Your component name.
         $eventdata->name              = 'submission'; // This is the message name from messages.php.
         $eventdata->userfrom          = \core_user::get_noreply_user();
@@ -46,6 +52,10 @@ class pp_receipt_message {
         $eventdata->fullmessagehtml   = $message;
         $eventdata->smallmessage      = '';
         $eventdata->notification      = 1; // This is only set to 0 for personal messages between users.
+
+        if ($CFG->branch >= 32) {
+            $eventdata->courseid = $courseid;
+        }
 
         message_send($eventdata);
     }

--- a/classes/digitalreceipt/pp_receipt_message.php
+++ b/classes/digitalreceipt/pp_receipt_message.php
@@ -52,10 +52,7 @@ class pp_receipt_message {
         $eventdata->fullmessagehtml   = $message;
         $eventdata->smallmessage      = '';
         $eventdata->notification      = 1; // This is only set to 0 for personal messages between users.
-
-        if ($CFG->branch >= 32) {
-            $eventdata->courseid = $courseid;
-        }
+        $eventdata->courseid          = $courseid;
 
         message_send($eventdata);
     }

--- a/lib.php
+++ b/lib.php
@@ -713,7 +713,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             } else if (!empty($linkarray["content"])) {
                 // Get turnitin text content details.
                 $submissiontype = ($cm->modname == "forum") ? 'forum_post' : 'text_content';
-                $content = $moduleobject->set_content($linkarray);
+                $content = $moduleobject->set_content($linkarray, $cm);
                 $identifier = sha1($content);
             }
 

--- a/lib.php
+++ b/lib.php
@@ -2956,7 +2956,7 @@ function plagiarism_turnitin_send_queued_submissions() {
             );
 
             $message = $receipt->build_message($input);
-            $receipt->send_message($user->id, $message);
+            $receipt->send_message($user->id, $message, $cm->course);
 
             // Output a message in the cron for successfull submission to Turnitin.
             $outputvars = new stdClass();


### PR DESCRIPTION
Fixed an issue where send_queued_files task would fail.
Changed depecated stdClass() to new \core\message\message() for event data.
Fixed an issue where the $cm parameter was not being passed in during a text submission.