### PR TITLE
Feature remove class dependency

### DIFF
--- a/backup/moodle2/backup_plagiarism_turnitin_plugin.class.php
+++ b/backup/moodle2/backup_plagiarism_turnitin_plugin.class.php
@@ -52,15 +52,14 @@ class backup_plagiarism_turnitin_plugin extends backup_plagiarism_plugin {
         $pluginelement = new backup_nested_element($this->get_recommended_name());
         $plugin->add_child($pluginelement);
 
-        // Add courses from Turnitintool table.
+        // Add courses from plagiarism_turnitin table.
         $turnitincourses = new backup_nested_element('turnitin_courses');
         $turnitincourse = new backup_nested_element('turnitin_course', array('id'),
-            array('courseid', 'ownerid', 'turnitin_ctl', 'turnitin_cid', 'course_type'));
+            array('courseid', 'ownerid', 'turnitin_ctl', 'turnitin_cid'));
         $pluginelement->add_child($turnitincourses);
         $turnitincourses->add_child($turnitincourse);
 
-        $turnitincourse->set_source_table('turnitintooltwo_courses', array('courseid' => backup::VAR_COURSEID,
-         'course_type' => backup_helper::is_sqlparam('PP')));
+        $turnitincourse->set_source_table('plagiarism_turnitin_courses', array('courseid' => backup::VAR_COURSEID));
         return $plugin;
     }
 }

--- a/backup/moodle2/restore_plagiarism_turnitin_plugin.class.php
+++ b/backup/moodle2/restore_plagiarism_turnitin_plugin.class.php
@@ -39,14 +39,16 @@ class restore_plagiarism_turnitin_plugin extends restore_plagiarism_plugin {
 
         if ($this->task->is_samesite()) {
             $data = (object)$data;
-            $recordexists = $DB->record_exists('turnitintooltwo_courses',
-                array('turnitin_cid' => $data->turnitin_cid, 'course_type' => 'PP'));
+            $recordexists = $DB->record_exists('plagiarism_turnitin_courses', array('turnitin_cid' => $data->turnitin_cid));
 
             if (!$recordexists) {
                 $data = (object)$data;
                 $data->courseid = $this->task->get_courseid();
 
-                $DB->insert_record('turnitintooltwo_courses', $data);
+                // Unset course type in case the restore is from a backup taken prior to change for where the courses are stored.
+                unset($data->course_type);
+
+                $DB->insert_record('plagiarism_turnitin_courses', $data);
             }
         }
     }

--- a/classes/turnitin_class.class.php
+++ b/classes/turnitin_class.class.php
@@ -36,8 +36,7 @@ class turnitin_class {
 
         $this->id = $id;
 
-        if ($turnitincourse = $DB->get_record('turnitintooltwo_courses',
-                                array("courseid" => $id, "course_type" => "PP"))) {
+        if ($turnitincourse = $DB->get_record('plagiarism_turnitin_courses', array("courseid" => $id))) {
             $this->turnitinid = $turnitincourse->turnitin_cid;
             $this->turnitintitle = $turnitincourse->turnitin_ctl;
         }

--- a/db/install.xml
+++ b/db/install.xml
@@ -36,7 +36,7 @@
                 <INDEX NAME="externalid" UNIQUE="false" FIELDS="externalid" />
             </INDEXES>
         </TABLE>
-        <TABLE NAME="plagiarism_turnitin_config" COMMENT="info about submitted files" PREVIOUS="plagiarism_turnitin_files">
+        <TABLE NAME="plagiarism_turnitin_config" COMMENT="info about submitted files" PREVIOUS="plagiarism_turnitin_files" NEXT="plagiarism_turnitin_courses">
             <FIELDS>
                 <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true" NEXT="cm"/>
                 <FIELD NAME="cm" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" PREVIOUS="id" NEXT="name"/>
@@ -48,6 +48,21 @@
                 <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="cm"/>
                 <KEY NAME="cm" TYPE="foreign" FIELDS="cm" REFTABLE="course_modules" REFFIELDS="id" ONDELETE="cascade" PREVIOUS="primary"/>
             </KEYS>
+        </TABLE>
+        <TABLE NAME="plagiarism_turnitin_courses" COMMENT="Turnitin Plagiarism Plugin Courses" PREVIOUS="plagiarism_turnitin_config">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="false" SEQUENCE="true" NEXT="courseid"/>
+                <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="false" SEQUENCE="false" PREVIOUS="id" NEXT="ownerid"/>
+                <FIELD NAME="ownerid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="false" SEQUENCE="false" PREVIOUS="courseid" NEXT="turnitin_ctl"/>
+                <FIELD NAME="turnitin_ctl" TYPE="text" LENGTH="medium" NOTNULL="true" UNSIGNED="false" SEQUENCE="false" PREVIOUS="ownerid" NEXT="turnitin_cid"/>
+                <FIELD NAME="turnitin_cid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="false" SEQUENCE="false" PREVIOUS="turnitin_ctl"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id" />
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid" />
+            </INDEXES>
         </TABLE>
     </TABLES>
 </XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -298,8 +298,8 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
         }
     }
 
-    if ($oldversion < 2018053101) {
-        // Define table plagiarism_turnitin_courses to be created.
+    if ($oldversion < 2018052402) {
+        // Define table file_conversion to be created.
         $table = new xmldb_table('plagiarism_turnitin_courses');
 
         // Adding fields to table plagiarism_turnitin_courses.
@@ -316,6 +316,30 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
         // Conditionally launch create table for file_conversion.
         if (!$dbman->table_exists($table)) {
             $dbman->create_table($table);
+        }
+
+        // If V2 is installed, copy the courses across from V2.
+        if ($DB->get_record('config_plugins', array('plugin' => 'mod_turnitintooltwo'))) {
+            $ppcourses = $DB->get_records('turnitintooltwo_courses', array('course_type' => 'PP'), 'id ASC', 'courseid, ownerid, turnitin_ctl, turnitin_cid');
+
+            foreach ($ppcourses as $ppcourse) {
+                $course = new stdClass();
+                $course->courseid = $ppcourse->courseid;
+                $course->ownerid = $ppcourse->ownerid;
+                $course->turnitin_cid = $ppcourse->turnitin_cid;
+                if (!$DB->get_record('plagiarism_turnitin_courses', array('courseid' => $ppcourse->courseid))) {
+                    $course->turnitin_ctl = $ppcourse->turnitin_ctl;
+                    $DB->insert_record('plagiarism_turnitin_courses', $course);
+
+
+                    // Clean up the record from the V2 plugin.
+                    $coursev2 = array('courseid' => $ppcourse->courseid,
+                        'ownerid' => $ppcourse->ownerid,
+                        'turnitin_cid' => $ppcourse->turnitin_cid,
+                        'course_type' => 'PP');
+                    $DB->delete_records('turnitintooltwo_courses', $coursev2);
+                }
+            }
         }
     }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -298,6 +298,27 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
         }
     }
 
+    if ($oldversion < 2018053101) {
+        // Define table plagiarism_turnitin_courses to be created.
+        $table = new xmldb_table('plagiarism_turnitin_courses');
+
+        // Adding fields to table plagiarism_turnitin_courses.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('courseid', XMLDB_TYPE_INTEGER, '10', null, false, null, null, 'id');
+        $table->add_field('ownerid', XMLDB_TYPE_INTEGER, '10', null, false, null, null, 'courseid');
+        $table->add_field('turnitin_ctl', XMLDB_TYPE_TEXT, null, null, false, null, null, 'ownerid');
+        $table->add_field('turnitin_cid', XMLDB_TYPE_INTEGER, '10', null, false, null, null, 'turnitin_ctl');
+
+        // Adding keys and indexes to table plagiarism_turnitin_courses.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_index('courseid', XMLDB_INDEX_NOTUNIQUE, array('courseid'));
+
+        // Conditionally launch create table for file_conversion.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+    }
+
     return $result;
 }
 

--- a/lib.php
+++ b/lib.php
@@ -409,7 +409,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         // If all turnitin enabled modules for this course have been reset.
         // then remove the Turnitin course id from the database.
         if ($resetcourse) {
-            $DB->delete_records('plagiarism_turnitin_courses', array('courseid' => $courseid, 'course_type' => 'PP'));
+            $DB->delete_records('plagiarism_turnitin_courses', array('courseid' => $courseid));
         }
 
         return true;
@@ -2110,7 +2110,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $turnitincourse->ownerid = $USER->id;
         $turnitincourse->turnitin_cid = $turnitincid;
         $turnitincourse->turnitin_ctl = $coursedata->fullname . " (Moodle PP)";
-        $turnitincourse->course_type = 'PP';
 
         if (empty($coursedata->tii_rel_id)) {
             $method = "insert_record";

--- a/lib.php
+++ b/lib.php
@@ -409,7 +409,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         // If all turnitin enabled modules for this course have been reset.
         // then remove the Turnitin course id from the database.
         if ($resetcourse) {
-            $DB->delete_records('turnitintooltwo_courses', array('courseid' => $courseid, 'course_type' => 'PP'));
+            $DB->delete_records('plagiarism_turnitin_courses', array('courseid' => $courseid, 'course_type' => 'PP'));
         }
 
         return true;
@@ -2119,7 +2119,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $turnitincourse->id = $coursedata->tii_rel_id;
         }
 
-        if (!$DB->$method('turnitintooltwo_courses', $turnitincourse)) {
+        if (!$DB->$method('plagiarism_turnitin_courses', $turnitincourse)) {
             if ($workflowcontext != "cron") {
                 plagiarism_turnitin_print_error('classupdateerror', 'plagiarism_turnitin', null, null, __FILE__, __LINE__);
                 exit();

--- a/version.php
+++ b/version.php
@@ -19,7 +19,7 @@
  * @copyright 2012 iParadigms LLC
  */
 
-$plugin->version = 2018053001;
+$plugin->version = 2018053101;
 $plugin->release = "2.7+";
 $plugin->requires = 2014051200;
 $plugin->component = 'plagiarism_turnitin';


### PR DESCRIPTION
This pull request replaces the broken #316.

Note: Until the assignment logic is moved across then this will not remove all dependencies.

This is because when a new course is created in Moodle, it will only be created in the database tables when the first assignment/submission is made and the cron runs.

What this means is that the cron will call get_course_data, which in turn calls create_tii_course if a course doesn't exist. This then calls a function of the same name in turnitintooltwo_assignment class which inserts into turnitintooltwo_courses.

What does change in this PR is we now have a courses table with the data migrated across during a plugin upgrade, and all references to turnitintooltwo_courses have been removed with the new plagiarism_turnitin_courses table.

course_type field is removed in the new table as it is no longer required, however it remains in the V2 table as I believe the migration tool uses it.