### PR TITLE
Fix default settings errors and rename the plugin settings form.

### DIFF
--- a/classes/forms/turnitin_defaultsettingsform.class.php
+++ b/classes/forms/turnitin_defaultsettingsform.class.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plugin setup form for plagiarism_turnitin component
+ *
+ * @package   plagiarism_turnitin
+ * @copyright 2018 David Winn <dwinn@turnitin.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+class turnitin_defaultsettingsform extends moodleform {
+
+    // Define the form.
+    public function definition () {
+        global $CFG;
+
+        $mform = $this->_form;
+
+        require_once($CFG->dirroot.'/plagiarism/turnitin/classes/turnitin_view.class.php');
+
+        $turnitinview = new turnitin_view();
+        $turnitinview->add_elements_to_settings_form($mform, array(), "defaults");
+
+        $this->add_action_buttons(true);
+    }
+}

--- a/classes/forms/turnitin_setupform.class.php
+++ b/classes/forms/turnitin_setupform.class.php
@@ -29,7 +29,7 @@ global $CFG;
 require_once($CFG->dirroot.'/plagiarism/turnitin/lib.php');
 require_once($CFG->libdir."/formslib.php");
 
-class tiisetupform extends moodleform {
+class turnitin_setupform extends moodleform {
 
     // Define the form.
     public function definition() {

--- a/extras.php
+++ b/extras.php
@@ -24,9 +24,9 @@ require_once($CFG->libdir.'/tablelib.php');
 require_once(__DIR__."/lib.php");
 
 require_once($CFG->dirroot."/mod/turnitintooltwo/lib.php");
-require_once($CFG->dirroot."/plagiarism/turnitin/turnitinplugin_view.class.php");
+require_once($CFG->dirroot."/plagiarism/turnitin/classes/turnitin_view.class.php");
 
-$turnitinpluginview = new turnitinplugin_view();
+$turnitinview = new turnitin_view();
 
 $cmd = optional_param('cmd', "", PARAM_ALPHAEXT);
 $viewcontext = optional_param('view_context', "window", PARAM_ALPHAEXT);
@@ -71,7 +71,7 @@ switch ($cmd) {
 }
 
 // Build page.
-echo $turnitinpluginview->output_header($_SERVER["REQUEST_URI"]);
+echo $turnitinview->output_header($_SERVER["REQUEST_URI"]);
 
 echo html_writer::tag("div", $viewcontext, array("id" => "tii_view_context"));
 

--- a/settings.php
+++ b/settings.php
@@ -116,9 +116,9 @@ switch ($do) {
     case "config":
         $turnitinview->draw_settings_tab_menu('turnitinsettings', $notice);
 
-        require_once(__DIR__ . '/classes/forms/tiisetupform.class.php');
+        require_once(__DIR__ . '/classes/forms/turnitin_setupform.class.php');
 
-        $tiisetupform = new tiisetupform();
+        $tiisetupform = new turnitin_setupform();
 
         // Save posted form data.
         if (($data = $tiisetupform->get_data()) && confirm_sesskey()) {
@@ -136,7 +136,9 @@ switch ($do) {
     case "defaults":
         $turnitinview->draw_settings_tab_menu('turnitindefaults', $notice);
 
-        $mform = new turnitin_plagiarism_plugin_form($CFG->wwwroot.'/plagiarism/turnitin/settings.php?do=defaults');
+        require_once(__DIR__ . '/classes/forms/turnitin_defaultsettingsform.class.php');
+
+        $mform = new turnitin_defaultsettingsform($CFG->wwwroot.'/plagiarism/turnitin/settings.php?do=defaults');
         $mform->set_data($plugindefaults);
         $mform->display();
         break;


### PR DESCRIPTION
Fix errors when accessing default settings due to the relocation of the view class. It was being called by a class in Moodle Direct v2 - This dependency has been removed but the redundant code can't be removed from V2 until we release this.

Also renamed the setup form to be consistent with other classes.