### PR TITLE
Removing courseid parameter for Moodle 3.1 and below

### DIFF
--- a/classes/digitalreceipt/pp_receipt_message.php
+++ b/classes/digitalreceipt/pp_receipt_message.php
@@ -52,7 +52,10 @@ class pp_receipt_message {
         $eventdata->fullmessagehtml   = $message;
         $eventdata->smallmessage      = '';
         $eventdata->notification      = 1; // This is only set to 0 for personal messages between users.
-        $eventdata->courseid          = $courseid;
+
+        if ($CFG->branch >= 32) {
+            $eventdata->courseid = $courseid;
+        }
 
         message_send($eventdata);
     }


### PR DESCRIPTION
This fixes the issue where the scheduled task `send queued files` would fail in Moodle 3.1 and below due to an invalid courseid parameter.