### PR TITLE
Update behat_plagiarism_turnitin.php

### DIFF
--- a/tests/behat/behat_plagiarism_turnitin.php
+++ b/tests/behat/behat_plagiarism_turnitin.php
@@ -4,7 +4,7 @@
 
 global $CFG;
 
-require_once($CFG->libdir.'/behat/behat_base.php');
+require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
 
 class behat_plagiarism_turnitin extends behat_base {
 


### PR DESCRIPTION
- Revert the behat lib dir path as $CFG is not loaded when we run the behat tests