### PR TITLE
Fix behat tests and add missing string

### DIFF
--- a/classes/turnitin_user.class.php
+++ b/classes/turnitin_user.class.php
@@ -17,6 +17,7 @@
 use Integrations\PhpSdk\TiiUser;
 use Integrations\PhpSdk\TiiPseudoUser;
 use Integrations\PhpSdk\TiiMembership;
+use Integrations\PhpSdk\TurnitinApiException;
 
 /**
  * @package   plagiarism_turnitin
@@ -175,7 +176,7 @@ class turnitin_user {
         if (empty($this->tiiuserid)) {
             try {
                 $this->tiiuserid = $this->find_tii_user_id();
-            } catch (Exception $e) {
+            } catch (TurnitinApiException $e) {
                 $this->tiiuserid = $this->create_tii_user();
             }
 
@@ -189,8 +190,8 @@ class turnitin_user {
     /**
      * Check Turnitin to see if this user has previously registered
      *
-     * @param object $user_details A data object for the user
-     * @return var Turnitin user id if found otherwise null
+     * @return integer Turnitin user id if found otherwise null
+     * @throws TurnitinApiException
      */
     private function find_tii_user_id() {
         $config = plagiarism_plugin_turnitin::plagiarism_turnitin_admin_config();
@@ -215,7 +216,9 @@ class turnitin_user {
                 $tiiuserid = null;
             }
             return $tiiuserid;
-
+        } catch (TurnitinApiException $e) {
+            // In case of a Turnitin exception we rethrow as get_tii_user_id will catch this exception.
+            throw $e;
         } catch (Exception $e) {
             $toscreen = ($this->workflowcontext == "cron") ? false : true;
             $turnitincomms->handle_exceptions($e, 'userfinderror', $toscreen);

--- a/classes/turnitin_user.class.php
+++ b/classes/turnitin_user.class.php
@@ -173,10 +173,12 @@ class turnitin_user {
         }
 
         if (empty($this->tiiuserid)) {
-            $this->tiiuserid = $this->find_tii_user_id();
-            if (empty($this->tiiuserid) && $this->enrol) {
+            try {
+                $this->tiiuserid = $this->find_tii_user_id();
+            } catch (Exception $e) {
                 $this->tiiuserid = $this->create_tii_user();
             }
+
             if (!empty($this->tiiuserid)) {
                 $this->save_tii_user();
             }

--- a/lang/ar/plagiarism_turnitin.php
+++ b/lang/ar/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'لا توجد اوليات للعرض';
 $string['sinfo'] = 'يتم عرض _البداية_الى_النهاية_من_الادخالات_الكلية.';
 $string['userupdateerror'] = 'لا يمكن تحديث بيانات المستخدم';
 $string['connecttestcommerror'] = 'تعذر الاتصال بـ Turnitin. يرجى التأكد من إعداد API URL. ';
+$string['userfinderror'] = 'حدث خطأ عند محاولة إيجاد المستخدم في Turnitin';

--- a/lang/cs/plagiarism_turnitin.php
+++ b/lang/cs/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Žádné záznamy k zobrazení.';
 $string['sinfo'] = 'Showing _START_ to _END_ of _TOTAL_ entries.';
 $string['userupdateerror'] = 'Nelze aktualizovat uživatelské údaje';
 $string['connecttestcommerror'] = 'Nebylo možné se k Turnitin připojit. Zkontrolujte své API URL nastavení.';
+$string['userfinderror'] = 'Došlo k chybě při hledání uživatele v systému Turnitin';

--- a/lang/de/plagiarism_turnitin.php
+++ b/lang/de/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Keine Daten vorhanden';
 $string['sinfo'] = 'Anzeigen _START_ bis _END_ von _TOTAL_ Einträgen.';
 $string['userupdateerror'] = 'Benutzerdaten konnten nicht aktualisiert werden.';
 $string['connecttestcommerror'] = 'Keine Verbindung mit Turnitin möglich. Überprüfen Sie Ihre API-URL-Einstellung.';
+$string['userfinderror'] = 'Beim Suchen des Benutzers in Turnitin ist ein Fehler aufgetreten.';

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -299,3 +299,5 @@ $string['szerorecords'] = 'No records to display.';
 $string['sinfo'] = 'Showing _START_ to _END_ of _TOTAL_ entries.';
 $string['userupdateerror'] = 'Could not update user data';
 $string['connecttestcommerror'] = 'Could not connect to Turnitin. Double check your API URL setting.';
+
+$string['userfinderror'] = 'There was an error trying to find the user in Turnitin';

--- a/lang/es/plagiarism_turnitin.php
+++ b/lang/es/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'No hay registros que mostrar.';
 $string['sinfo'] = 'Mostrando _TOTAL_ de entradas de _START_ a _END_';
 $string['userupdateerror'] = 'No se han podido actualizar los datos del usuario';
 $string['connecttestcommerror'] = 'No se pudo conectar a Turnitin. Comprueba nuevamente tu configuración de URL de API.';
+$string['userfinderror'] = 'Ha ocurrido un error al intentar encontrar al usuario en Turnitin';

--- a/lang/fi/plagiarism_turnitin.php
+++ b/lang/fi/plagiarism_turnitin.php
@@ -269,3 +269,4 @@ $string['szerorecords'] = 'Ei esitettäviä tiedostoja.';
 $string['sinfo'] = 'Näyttää _ALUSTA _LOPPUUN _palautusten _KOKONAISLUKUMÄÄRÄSTÄ.';
 $string['userupdateerror'] = 'Käyttäjätietoja ei voitu päivittää';
 $string['connecttestcommerror'] = 'Turnitiniin ei saatu yhteyttä. Tarkasta API:n URL-asetus.';
+$string['userfinderror'] = 'Kun käyttäjää haettiin Turnitinistä, kohdattiin virhe';

--- a/lang/fr/plagiarism_turnitin.php
+++ b/lang/fr/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Il n´y a aucun document à afficher';
 $string['sinfo'] = 'Montrer_TOTAL_des_entrées_du_DEBUT_à_la_FIN';
 $string['userupdateerror'] = 'Impossible d&#39;actualiser les informations de l’utilisateur';
 $string['connecttestcommerror'] = 'Impossible de se connecter à Turnitin. Veuillez vérifier les paramètres de l’URL de l’API.';
+$string['userfinderror'] = 'Une erreur est survenue en cherchant l´utilisateur Turnitin';

--- a/lang/it/plagiarism_turnitin.php
+++ b/lang/it/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Nessun record da visualizzare.';
 $string['sinfo'] = 'Showing _START_ to _END_ of _TOTAL_ entries.';
 $string['userupdateerror'] = 'Impossibile aggiornare i dati dell&#39;utente';
 $string['connecttestcommerror'] = 'Impossibile connettersi a Turnitin. Verifica l&#39;impostazione dell&#39;URL API.';
+$string['userfinderror'] = 'Si è verificato un errore nel tentativo di trovare l&#39;utente Turnitin';

--- a/lang/ja/plagiarism_turnitin.php
+++ b/lang/ja/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = '表示できる記録がありません。';
 $string['sinfo'] = '_START_～_END_（全_TOTAL_）エントリを表示';
 $string['userupdateerror'] = 'ユーザーデータを講師できませんでした';
 $string['connecttestcommerror'] = 'Turnitinに接続できませんでした。APIのURL設定を確認してください。';
+$string['userfinderror'] = 'Turnitinのユーザーを検索中にエラーが発生しました';

--- a/lang/ko/plagiarism_turnitin.php
+++ b/lang/ko/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = '기록이 없음';
 $string['sinfo'] = '_START_ to _END_ 의 _TOTAL_ 사항 표시';
 $string['userupdateerror'] = '사용자 데이타를 업데이트할 수 없었음';
 $string['connecttestcommerror'] = 'Turnitin에 연결할 수 없었습니다. API URL 환경을 재확인하시기 바랍니다.';
+$string['userfinderror'] = 'Turnitin에 있는 사용자를 찾는 데 오류가 발생하였습니다';

--- a/lang/nl/plagiarism_turnitin.php
+++ b/lang/nl/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Geen gegevens beschikbaar.';
 $string['sinfo'] = 'Toont _START_ tot _END_ van _TOTAL_ items.';
 $string['userupdateerror'] = 'Kan gebruikersgegevens niet bijwerken';
 $string['connecttestcommerror'] = 'Kan geen verbinding maken met Turnitin. Controleer uw API URL-instelling';
+$string['userfinderror'] = 'Er is een fout opgetreden tijdens het zoeken naar de gebruiker in Turnitin';

--- a/lang/pl/plagiarism_turnitin.php
+++ b/lang/pl/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Brak wyników do pokazania.';
 $string['sinfo'] = 'Pokazuje od _START_do_END__TOTAL_wpisy.';
 $string['userupdateerror'] = 'Aktualizacja danych użytkownika nie powiodła się';
 $string['connecttestcommerror'] = 'Nie udało się połączyć z Turnitin. Sprawdź swoje ustawienia URL API.';
+$string['userfinderror'] = 'Wystąpił błąd przy próbie znalezienia użytkownika w Turnitin';

--- a/lang/pt_br/plagiarism_turnitin.php
+++ b/lang/pt_br/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Não há registros para exibir';
 $string['sinfo'] = 'Exibindo registros_START_ao_END_do_TOTAL';
 $string['userupdateerror'] = 'Não foi possível atualizar os dados do usuário';
 $string['connecttestcommerror'] = 'Não foi possível conectar ao Turnitin. Verifique as suas configurações do API URL';
+$string['userfinderror'] = 'Ocorreu um erro ao tentar encontrar o trabalho no Turnitin';

--- a/lang/ro/plagiarism_turnitin.php
+++ b/lang/ro/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Nu există date de afișat.';
 $string['sinfo'] = 'Se afișează intrările _START_ – _END_ din _TOTAL_.';
 $string['userupdateerror'] = 'Imposibil de actualizat datele utilizatorilor';
 $string['connecttestcommerror'] = 'Imposibil de conectat la Turnitin. Verificați setarea URL-ului API.';
+$string['userfinderror'] = 'Eroare la încercarea de a găsi utilizatorul în Turnitin';

--- a/lang/ru/plagiarism_turnitin.php
+++ b/lang/ru/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Нет записей для отображения';
 $string['sinfo'] = 'Отображены элементы с _ПЕРВОГО_ до _ПОСЛЕДНЕГО_, _ВСЕГО_ элементов';
 $string['userupdateerror'] = 'Не удалось обновить данные пользователя';
 $string['connecttestcommerror'] = 'Не удалось подключиться к Turnitin. Проверьте настройки URL-адреса API.';
+$string['userfinderror'] = 'Возникла ошибка при попытке найти пользователя в Turnitin';

--- a/lang/sv/plagiarism_turnitin.php
+++ b/lang/sv/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Inga uppgifter att visa.';
 $string['sinfo'] = 'Visar _START_till_END_av_TOTAL_inlägg.';
 $string['userupdateerror'] = 'Kunde inte uppdatera användardata';
 $string['connecttestcommerror'] = 'Kunde inte ansluta till Turnitin. Dubbelkolla din inställningen för API-webbadressen.';
+$string['userfinderror'] = 'Det uppstod ett fel vid försök att hitta användaren i Turnitin';

--- a/lang/tr/plagiarism_turnitin.php
+++ b/lang/tr/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Gösterilecek kayıt yok.';
 $string['sinfo'] = '_START_ /_END_ of _TOTAL_ giriş gösteriliyor.';
 $string['userupdateerror'] = 'Kullanıcı verileri güncellenemedi';
 $string['connecttestcommerror'] = 'Turnitin&#39; e bağlanılamadı. API URL ayarlarını tekrar kontrol edin.';
+$string['userfinderror'] = 'Kullanıcı Turnitin&#39;de aranırken bir sorun oluştu';

--- a/lang/vi/plagiarism_turnitin.php
+++ b/lang/vi/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = 'Không có kết quả nào để hiển thị.';
 $string['sinfo'] = 'Hiển thị _START_ đến _END_ trong _TOTAL_ mục.';
 $string['userupdateerror'] = 'Không thể cập nhật dữ liệu người dùng';
 $string['connecttestcommerror'] = 'Không thể kết nối với Turnitin. Hãy kiểm tra lại cài đặt URL API của bạn.';
+$string['userfinderror'] = 'Xảy ra lỗi khi đang cố gắng tìm một người dùng trên Turnitin';

--- a/lang/zh_hans/plagiarism_turnitin.php
+++ b/lang/zh_hans/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = '无法显示任何记录。';
 $string['sinfo'] = '正在显示第 _START_ 到 _END_ 个条目，共 _TOTAL_ 个条目。';
 $string['userupdateerror'] = '无法更新用户数据';
 $string['connecttestcommerror'] = '无法连线至 Turnitin。请再次检查您的 API URL 设置。';
+$string['userfinderror'] = '尝试在 Turnitin 中查找用户时出错';

--- a/lang/zh_tw/plagiarism_turnitin.php
+++ b/lang/zh_tw/plagiarism_turnitin.php
@@ -267,3 +267,4 @@ $string['szerorecords'] = '無法顯示任何記錄。';
 $string['sinfo'] = '顯示 _START_ 到 _END_，總共 _TOTAL_ 個項目。';
 $string['userupdateerror'] = '無法更新使用者資料';
 $string['connecttestcommerror'] = '無法連線至 Turnitin。請再次檢查 API URL 設定。';
+$string['userfinderror'] = '嘗試在 Turnitin 內尋找使用者時發生錯誤';

--- a/lib.php
+++ b/lib.php
@@ -22,6 +22,7 @@
 use Integrations\PhpSdk\TiiClass;
 use Integrations\PhpSdk\TiiSubmission;
 use Integrations\PhpSdk\TiiAssignment;
+use Integrations\PhpSdk\TiiLTI;
 
 if (!defined('MOODLE_INTERNAL')) {
     die('Direct access to this script is forbidden.'); // It must be included from a Moodle page.

--- a/tests/behat/assignment.feature
+++ b/tests/behat/assignment.feature
@@ -21,13 +21,11 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     And I navigate to "Turnitin" node in "Site administration > Plugins > Plagiarism"
     And I set the following fields to these values:
       | Enable Turnitin            | 1 |
-      | Enable Turnitin for assign | 1 |
-    And I press "Save changes"
-    And I navigate to "Turnitin Assignment 2" node in "Site administration > Plugins > Activity modules"
+      | Enable Turnitin for Assign | 1 |
     And I configure Turnitin URL
     And I configure Turnitin credentials
     And I set the following fields to these values:
-      | Enable Diagnostic Mode | Standard |
+      | Enable Diagnostic Mode | Yes |
     And I press "Save changes"
     Then the following should exist in the "plugins-control-panel" table:
       | Plugin name         |

--- a/tests/behat/behat_plagiarism_turnitin.php
+++ b/tests/behat/behat_plagiarism_turnitin.php
@@ -50,12 +50,12 @@ class behat_plagiarism_turnitin extends behat_base {
             var option = document.createElement('option');
             option.setAttribute('value', '${apiurl}');
             var apiurl = document.createTextNode('${apiurl}');
-            var select = document.querySelector('#admin-apiurl select');
+            var select = document.querySelector('#id_plagiarism_turnitin_apiurl');
             option.appendChild(apiurl);
             select.appendChild(option);
         ";
         $this->getSession()->executeScript($javascript);
-        $this->getSession()->getPage()->find("css", "#admin-apiurl select")->selectOption($apiurl);
+        $this->getSession()->getPage()->find("css", "#id_plagiarism_turnitin_apiurl")->selectOption($apiurl);
     }
 
     /**
@@ -66,10 +66,10 @@ class behat_plagiarism_turnitin extends behat_base {
         $account = getenv('TII_ACCOUNT');
         $secret = getenv('TII_SECRET');
 
-        $this->getSession()->getPage()->find("css", "#admin-accountid input")->setValue($account);
+        $this->getSession()->getPage()->find("css", "#id_plagiarism_turnitin_accountid")->setValue($account);
 
         $this->getSession()->getPage()->find('css', '[title="Edit password"]')->click();
-        $this->getSession()->getPage()->find("css", "#admin-secretkey input")->setValue($secret);
+        $this->getSession()->getPage()->find("css", "#id_plagiarism_turnitin_secretkey")->setValue($secret);
     }
 
     /**

--- a/tests/behat/installed.feature
+++ b/tests/behat/installed.feature
@@ -26,5 +26,4 @@ Feature:  Installation succeeds
   Scenario: Test the plugin connectivity
     Given I navigate to "Turnitin" node in "Site administration > Plugins > Plagiarism"
     And I click on "#id_connection_test" "css_element"
-#    And I wait until "#connection-test-success" "css_element" exists
     Then I should see "Connection test successful"

--- a/tests/behat/installed.feature
+++ b/tests/behat/installed.feature
@@ -12,13 +12,11 @@ Feature:  Installation succeeds
     And I navigate to "Turnitin" node in "Site administration > Plugins > Plagiarism"
     And I set the following fields to these values:
       | Enable Turnitin            | 1 |
-      | Enable Turnitin for assign | 1 |
-    And I press "Save changes"
-    And I navigate to "Turnitin Assignment 2" node in "Site administration > Plugins > Activity modules"
+      | Enable Turnitin for Assign | 1 |
     And I configure Turnitin URL
     And I configure Turnitin credentials
     And I set the following fields to these values:
-      | Enable Diagnostic Mode | Standard |
+      | Enable Diagnostic Mode | Yes |
     And I press "Save changes"
     Then the following should exist in the "plugins-control-panel" table:
       | Plugin name         |
@@ -26,8 +24,7 @@ Feature:  Installation succeeds
 
   @javascript
   Scenario: Test the plugin connectivity
-    Given I navigate to "Turnitin Assignment 2" node in "Site administration > Plugins > Activity modules"
-    And I configure Turnitin URL
-    And I click on "#test_link" "css_element"
-    And I wait until "#test_result" "css_element" exists
-    Then I should see "Moodle has successfully connected to Turnitin."
+    Given I navigate to "Turnitin" node in "Site administration > Plugins > Plagiarism"
+    And I click on "#id_connection_test" "css_element"
+#    And I wait until "#connection-test-success" "css_element" exists
+    Then I should see "Connection test successful"


### PR DESCRIPTION
This pull request fixes the behat tests for this branch. The tests were built as part of develop and were calling V2 settings however this plugin has its own settings now that needed to be called.

Also fixed a findUser issue that was created as a result of the new SDK implementation, and added a language string which was missing for an error message.