### PR TITLE
Delegate access to errors page

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -38,4 +38,9 @@ $capabilities = array(
          'manager' => CAP_ALLOW
         )
     ),
+    'plagiarism/turnitin:viewerrorreport' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'legacy' => []
+    ]
 );

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -96,6 +96,7 @@ $string['filedoesnotexist'] = 'File has been deleted';
 $string['reportgenspeed_resubmission'] = 'You have already submitted a paper to this assignment and a Similarity Report was generated for your submission. If you choose to resubmit your paper, your earlier submission will be replaced and a new report will be generated. After {$a->num_resubmissions} resubmissions, you will need to wait {$a->num_hours} hours after a resubmission to see a new Similarity Report.';
 
 // Plugin settings.
+$string['viewerrorreport'] = 'View Error Report';
 $string['config'] = 'Configuration';
 $string['defaults'] = 'Default Settings';
 $string['showusage'] = 'Show Data Dump';
@@ -154,7 +155,6 @@ $string['launchpeermarkreviews'] = 'Launch Peermark Reviews';
 $string['ppqueuesize'] = 'Number of events in the Plagiarism Plugin events queue';
 $string['ppcronsubmissionlimitreached'] = 'No further submissions will be sent to Turnitin by this cron execution as only {$a} are processed per run';
 $string['cronsubmittedsuccessfully'] = 'Submission: {$a->title} (TII ID: {$a->submissionid}) for the assignment {$a->assignmentname} on the course {$a->coursename} was successfully submitted to Turnitin.';
-$string['pp_submission_error'] = 'Turnitin has returned an error with your submission:';
 $string['turnitindeletionerror'] = 'Turnitin submission deletion failed. The local Moodle copy was removed but the submission in Turnitin could not be deleted.';
 $string['ppeventsfailedconnection'] = 'No events will be processed by the Turnitin plagiarism plugin by this cron execution as a connection to Turnitin can not be established.';
 

--- a/turnitinplugin_view.class.php
+++ b/turnitinplugin_view.class.php
@@ -32,20 +32,30 @@ class turnitinplugin_view {
      *
      * @param string $currenttab The currect tab to be styled as selected
      */
-    public function draw_settings_tab_menu($currenttab, $notice = null) {
+    public function draw_settings_tab_menu($currenttab, $notice = null, $hidetabs = null) {
         global $OUTPUT;
 
         $tabs = array();
-        $tabs[] = new tabobject('turnitinsettings', 'settings.php',
-                        get_string('config', 'plagiarism_turnitin'), get_string('config', 'plagiarism_turnitin'), false);
-        $tabs[] = new tabobject('turnitindefaults', 'settings.php?do=defaults',
-                        get_string('defaults', 'plagiarism_turnitin'), get_string('defaults', 'plagiarism_turnitin'), false);
-        $tabs[] = new tabobject('turnitinshowusage', 'settings.php?do=viewreport',
-                        get_string('showusage', 'plagiarism_turnitin'), get_string('showusage', 'plagiarism_turnitin'), false);
-        $tabs[] = new tabobject('turnitinsaveusage', 'settings.php?do=savereport',
-                        get_string('saveusage', 'plagiarism_turnitin'), get_string('saveusage', 'plagiarism_turnitin'), false);
-        $tabs[] = new tabobject('turnitinerrors', 'settings.php?do=errors',
-                        get_string('errors', 'plagiarism_turnitin'), get_string('errors', 'plagiarism_turnitin'), false);
+        if (is_null($hidetabs) ||  !in_array('config', $hidetabs)) {
+            $tabs[] = new tabobject('turnitinsettings', 'settings.php',
+                get_string('config', 'plagiarism_turnitin'), get_string('config', 'plagiarism_turnitin'), false);
+        }
+        if (is_null($hidetabs) ||  !in_array('defaults', $hidetabs)) {
+            $tabs[] = new tabobject('turnitindefaults', 'settings.php?do=defaults',
+                get_string('defaults', 'plagiarism_turnitin'), get_string('defaults', 'plagiarism_turnitin'), false);
+        }
+        if (is_null($hidetabs) ||  !in_array('showusage', $hidetabs)) {
+            $tabs[] = new tabobject('turnitinshowusage', 'settings.php?do=viewreport',
+                get_string('showusage', 'plagiarism_turnitin'), get_string('showusage', 'plagiarism_turnitin'), false);
+        }
+        if (is_null($hidetabs) ||  !in_array('saveusage', $hidetabs)) {
+            $tabs[] = new tabobject('turnitinsaveusage', 'settings.php?do=savereport',
+                get_string('saveusage', 'plagiarism_turnitin'), get_string('saveusage', 'plagiarism_turnitin'), false);
+        }
+        if (is_null($hidetabs) ||  !in_array('errors', $hidetabs)) {
+            $tabs[] = new tabobject('turnitinerrors', 'settings.php?do=errors',
+                get_string('errors', 'plagiarism_turnitin'), get_string('errors', 'plagiarism_turnitin'), false);
+        }
         print_tabs(array($tabs), $currenttab);
 
         if (!is_null($notice)) {

--- a/version.php
+++ b/version.php
@@ -19,7 +19,7 @@
  * @copyright 2012 iParadigms LLC
  */
 
-$plugin->version = 2018082802;
+$plugin->version = 2018082803;
 $plugin->release = "2.7+";
 $plugin->requires = 2014051200;
 $plugin->component = 'plagiarism_turnitin';


### PR DESCRIPTION
It would be good if access to the errors tab was available to not just users with site:config capability.

We have a delegated responsibility and resubmitting failed attempts is a pretty low-grade action that shouldn't need an admin to do! (and it happens very frequently).

Small initial prototype change to implement #482 and allow access to the Errors page to be delegated to a user with appropriate capabilties.
