### PR TITLE
Reuse user or unenrol if using unique user.

### DIFF
--- a/tests/behat/assignment.feature
+++ b/tests/behat/assignment.feature
@@ -8,8 +8,10 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 0         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment.feature
+++ b/tests/behat/assignment.feature
@@ -10,8 +10,8 @@ Feature: Plagiarism plugin works with a Moodle Assignment
       | Course 1 | C1        | 0        | 0         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment_any_file_type.feature
+++ b/tests/behat/assignment_any_file_type.feature
@@ -8,8 +8,10 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 0         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment_any_file_type.feature
+++ b/tests/behat/assignment_any_file_type.feature
@@ -10,8 +10,8 @@ Feature: Plagiarism plugin works with a Moodle Assignment
       | Course 1 | C1        | 0        | 0         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment_drafts.feature
+++ b/tests/behat/assignment_drafts.feature
@@ -10,9 +10,9 @@ Feature: Plagiarism plugin works with a Moodle Assignment
       | Course 1 | C1        | 0        | 0         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
-      | student2    | student2    | student2    | student2_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
+      | student2    | student2    | student2    | student2_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment_drafts.feature
+++ b/tests/behat/assignment_drafts.feature
@@ -8,9 +8,11 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 0         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "student2"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | student2    | student2    | student2    | student2_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment_groups.feature
+++ b/tests/behat/assignment_groups.feature
@@ -14,9 +14,9 @@ Feature: Group assignment submissions
       | Course 1 | C1        | 0        | 1         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
-      | student2    | student2    | student2    | student2_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
+      | student2    | student2    | student2    | student2_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role           |
       | student1    | C1     | student        |

--- a/tests/behat/assignment_groups.feature
+++ b/tests/behat/assignment_groups.feature
@@ -12,9 +12,11 @@ Feature: Group assignment submissions
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 1         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "student2"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | student2    | student2    | student2    | student2_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role           |
       | student1    | C1     | student        |

--- a/tests/behat/assignment_multiple_files.feature
+++ b/tests/behat/assignment_multiple_files.feature
@@ -8,8 +8,10 @@ Feature: Plagiarism plugin works with a Moodle Assignment and multiple files.
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 0         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment_multiple_files.feature
+++ b/tests/behat/assignment_multiple_files.feature
@@ -10,8 +10,8 @@ Feature: Plagiarism plugin works with a Moodle Assignment and multiple files.
       | Course 1 | C1        | 0        | 0         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment_resubmission.feature
+++ b/tests/behat/assignment_resubmission.feature
@@ -8,8 +8,10 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 0         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/assignment_resubmission.feature
+++ b/tests/behat/assignment_resubmission.feature
@@ -10,8 +10,8 @@ Feature: Plagiarism plugin works with a Moodle Assignment
       | Course 1 | C1        | 0        | 0         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/behat_plagiarism_turnitin.php
+++ b/tests/behat/behat_plagiarism_turnitin.php
@@ -22,11 +22,14 @@
  */
 
 // NOTE: no MOODLE_INTERNAL test here, this file may be required by behat before including /config.php.
-
 require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
+require_once(__DIR__ . '/../../vendor/autoload.php');
 
+use Behat\Gherkin\Node\TableNode as TableNode;
 use Behat\Mink\Exception\ExpectationException as ExpectationException;
 use Behat\Mink\Exception\ElementNotFoundException as ElementNotFoundException;
+use Integrations\PhpSdk\TiiMembership;
+use Integrations\PhpSdk\TurnitinAPI;
 
 class behat_plagiarism_turnitin extends behat_base {
 
@@ -213,5 +216,108 @@ class behat_plagiarism_turnitin extends behat_base {
         } catch (Exception $e) {
             // EULA not found - so skip it.
         }
+    }
+
+
+    /**
+     * @Given /^the following users will be created if they do not already exist:$/
+     * @param TableNode $data
+     * @throws Exception
+     */
+    public function the_following_users_will_be_created_if_they_do_not_already_exist(TableNode $data) {
+        $newdata = array();
+        $rowNum = 0;
+        foreach ($data->getRows() as $row) {
+            if (!$rowNum == 0) { // not header row
+                $row[3] = $row[0] . "_". getenv('TII_ACCOUNT') . ".tiibehattesting@example.com";
+            }
+            $rowNum++;
+            $newdata[] = $row;
+        }
+        $tablenode = new TableNode($newdata);
+        $this->execute('behat_data_generators::the_following_exist', array('users', $tablenode));
+    }
+
+
+    /**
+     * @Given /^I unenroll the user account "(?P<student>(?:[^"]|\\")*)" with the role "(?P<role>(?:[^"]|\\")*)" from the class in Turnitin$/
+     * @throws Exception
+     */
+    public function i_unenroll_the_user_account_with_the_role_from_the_class_in_turnitin($student, $role) {
+        global $DB;
+
+        $course = $DB->get_record("course", array("fullname" => "Turnitin Behat EULA Test Course"), 'id', MUST_EXIST);
+        $tiicourse = $DB->get_record('plagiarism_turnitin_courses', array("courseid" => $course->id), 'turnitin_cid', MUST_EXIST);
+
+        // Get the user.
+        $user = $DB->get_record("user", array("username" => $student), 'id', MUST_EXIST);
+        $tiiuser = $DB->get_record('plagiarism_turnitin_users', array("userid" => $user->id), 'turnitin_uid', MUST_EXIST);
+
+        $turnitincall = $this->behat_initialise_api(getenv('TII_ACCOUNT'), getenv('TII_SECRET'), getenv('TII_APIBASEURL'));
+
+        // Find the membership IDs for this user/class/role and delete them.
+        $membership = new TiiMembership();
+        $membership->setClassId($tiicourse->turnitin_cid);
+        $membership->setUserId($tiiuser->turnitin_uid);
+        $membership->setRole($role);
+
+        $response = $turnitincall->findMemberships($membership);
+        $findmembership = $response->getMembership();
+        $membershipids = $findmembership->getMembershipIds();
+
+        try {
+            foreach ($membershipids as $membershipid) {
+                $membership->setMembershipId($membershipid);
+                $turnitincall->deleteMembership($membership);
+            }
+        } catch (Exception $e) {
+            // ignore exception.
+        }
+    }
+
+    /**
+     * Initialise the API object for a behat call.
+     *
+     * @return object \APITurnitin
+     */
+    public function behat_initialise_api( ) {
+        global $CFG;
+
+        $api = new TurnitinAPI(getenv('TII_ACCOUNT'), getenv('TII_APIBASEURL'), getenv('TII_SECRET'), 12);
+
+        // Use Moodle's proxy settings if specified.
+        if (!empty($CFG->proxyhost)) {
+            $api->setProxyHost($CFG->proxyhost);
+        }
+
+        if (!empty($CFG->proxyport)) {
+            $api->setProxyPort($CFG->proxyport);
+        }
+
+        if (!empty($CFG->proxyuser)) {
+            $api->setProxyUser($CFG->proxyuser);
+        }
+
+        if (!empty($CFG->proxypassword)) {
+            $api->setProxyPassword($CFG->proxypassword);
+        }
+
+        if (!empty($CFG->proxytype)) {
+            $api->setProxyType($CFG->proxytype);
+        }
+
+        if (!empty($CFG->proxybypass)) {
+            $api->setProxyBypass($CFG->proxybypass);
+        }
+
+        $api->setIntegrationVersion($CFG->version);
+        $api->setPluginVersion(get_config('plagiarism_turnitin', 'version'));
+
+        if (is_readable("$CFG->dataroot/moodleorgca.crt")) {
+            $certificate = realpath("$CFG->dataroot/moodleorgca.crt");
+            $api->setSSLCertificate($certificate);
+        }
+
+        return $api;
     }
 }

--- a/tests/behat/behat_plagiarism_turnitin.php
+++ b/tests/behat/behat_plagiarism_turnitin.php
@@ -228,7 +228,7 @@ class behat_plagiarism_turnitin extends behat_base {
         $rowNum = 0;
         foreach ($data->getRows() as $row) {
             if (!$rowNum == 0) { // not header row
-                $row[3] = $row[0] . "_". getenv('TII_ACCOUNT') . ".tiibehattesting@example.com";
+                $row[3] = str_replace('$account', getenv('TII_ACCOUNT'), $row[3]);
             }
             $rowNum++;
             $newdata[] = $row;

--- a/tests/behat/behat_plagiarism_turnitin.php
+++ b/tests/behat/behat_plagiarism_turnitin.php
@@ -218,7 +218,6 @@ class behat_plagiarism_turnitin extends behat_base {
         }
     }
 
-
     /**
      * @Given /^the following users will be created if they do not already exist:$/
      * @param TableNode $data
@@ -237,7 +236,6 @@ class behat_plagiarism_turnitin extends behat_base {
         $tablenode = new TableNode($newdata);
         $this->execute('behat_data_generators::the_following_exist', array('users', $tablenode));
     }
-
 
     /**
      * @Given /^I unenroll the user account "(?P<student>(?:[^"]|\\")*)" with the role "(?P<role>(?:[^"]|\\")*)" from the class in Turnitin$/

--- a/tests/behat/eula.feature
+++ b/tests/behat/eula.feature
@@ -10,7 +10,7 @@ Feature: Plagiarism plugin works with a Moodle Assignment
       | Turnitin Behat EULA Test Course | C1        | 0        | 0         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
     And I create a unique user with username "student1"
     And the following "course enrolments" exist:
       | user        | course | role    |

--- a/tests/behat/eula.feature
+++ b/tests/behat/eula.feature
@@ -7,9 +7,11 @@ Feature: Plagiarism plugin works with a Moodle Assignment
   Background: Set up the plugin
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
-      | Course 1 | C1        | 0        | 0         |
+      | Turnitin Behat EULA Test Course | C1        | 0        | 0         |
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
     And I create a unique user with username "student1"
-    And I create a unique user with username "instructor1"
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |
@@ -31,7 +33,7 @@ Feature: Plagiarism plugin works with a Moodle Assignment
       | Plugin name         |
       | plagiarism_turnitin |
     # Create Assignment.
-    And I am on "Course 1" course homepage with editing mode on
+    And I am on "Turnitin Behat EULA Test Course" course homepage with editing mode on
     And I add a "Assignment" to section "1" and I fill the form with:
       | Assignment name                   | Test assignment name |
       | use_turnitin                      | 1                    |
@@ -43,7 +45,7 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     Given I log out
     # Student declines the EULA and submits.
     And I log in as "student1"
-    And I am on "Course 1" course homepage
+    And I am on "Turnitin Behat EULA Test Course" course homepage
     And I follow "Test assignment name"
     And I press "Add submission"
     Then I should see "To submit a file to Turnitin you must first accept our EULA. Choosing to not accept our EULA will submit your file to Moodle only. Click here to accept."
@@ -65,7 +67,7 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     # Instructor opens assignment.
     And I log out
     And I log in as "instructor1"
-    And I am on "Course 1" course homepage
+    And I am on "Turnitin Behat EULA Test Course" course homepage
     And I follow "Test assignment name"
     Then I should see "View all submissions"
     When I navigate to "View all submissions" in current page administration
@@ -73,7 +75,7 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     Given I log out
     # Student accepts the EULA.
     And I log in as "student1"
-    And I am on "Course 1" course homepage
+    And I am on "Turnitin Behat EULA Test Course" course homepage
     And I follow "Test assignment name"
     And I should see "Your file has not been submitted to Turnitin. Please click here to accept our EULA."
     And I should see "This file has not been submitted to Turnitin because the user has not accepted the Turnitin End User Licence Agreement."
@@ -91,7 +93,7 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     # Instructor opens assignment.
     And I log out
     And I log in as "instructor1"
-    And I am on "Course 1" course homepage
+    And I am on "Turnitin Behat EULA Test Course" course homepage
     And I follow "Test assignment name"
     Then I should see "View all submissions"
     When I navigate to "View all submissions" in current page administration
@@ -99,11 +101,11 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     # Trigger cron as admin for report
     And I log out
     And I log in as "admin"
-    And I obtain an originality report for "student1 student1" on "assignment" "Test assignment name" on course "Course 1"
+    And I obtain an originality report for "student1 student1" on "assignment" "Test assignment name" on course "Turnitin Behat EULA Test Course"
     # Instructor opens viewer
     And I log out
     And I log in as "instructor1"
-    And I am on "Course 1" course homepage
+    And I am on "Turnitin Behat EULA Test Course" course homepage
     And I follow "Test assignment name"
     Then I should see "View all submissions"
     When I navigate to "View all submissions" in current page administration
@@ -115,3 +117,4 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     And I accept the Turnitin EULA from the EV if necessary
     And I wait until the page is ready
     Then I should see "testfile.txt"
+    Then I unenroll the user account "student1" with the role "Learner" from the class in Turnitin

--- a/tests/behat/forum.feature
+++ b/tests/behat/forum.feature
@@ -8,8 +8,10 @@ Feature: Plagiarism plugin works with a Moodle forum
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 0         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/forum.feature
+++ b/tests/behat/forum.feature
@@ -10,8 +10,8 @@ Feature: Plagiarism plugin works with a Moodle forum
       | Course 1 | C1        | 0        | 0         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/pseudo_submission.feature
+++ b/tests/behat/pseudo_submission.feature
@@ -8,8 +8,10 @@ Feature: Plagiarism plugin works with a Moodle Assignment
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 0         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/pseudo_submission.feature
+++ b/tests/behat/pseudo_submission.feature
@@ -10,8 +10,8 @@ Feature: Plagiarism plugin works with a Moodle Assignment
       | Course 1 | C1        | 0        | 0         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/workshop.feature
+++ b/tests/behat/workshop.feature
@@ -8,8 +8,10 @@ Feature: Plagiarism plugin works with a Moodle Workshop
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
       | Course 1 | C1        | 0        | 1         |
-    And I create a unique user with username "student1"
-    And I create a unique user with username "instructor1"
+    And the following users will be created if they do not already exist:
+      | username    | firstname   | lastname    | email                                   |
+      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |

--- a/tests/behat/workshop.feature
+++ b/tests/behat/workshop.feature
@@ -10,8 +10,8 @@ Feature: Plagiarism plugin works with a Moodle Workshop
       | Course 1 | C1        | 0        | 1         |
     And the following users will be created if they do not already exist:
       | username    | firstname   | lastname    | email                                   |
-      | instructor1 | instructor1 | instructor1 | instructor1_tiibehattesting@example.com |
-      | student1    | student1    | student1    | student1_tiibehattesting@example.com    |
+      | instructor1 | instructor1 | instructor1 | instructor1_$account_tiibehattesting@example.com |
+      | student1    | student1    | student1    | student1_$account_tiibehattesting@example.com    |
     And the following "course enrolments" exist:
       | user        | course | role    |
       | student1    | C1     | student |


### PR DESCRIPTION
This pull request makes improvements to the way users are handled within behat tests.

- The tests will first attempt to use an existing test account, otherwise create a new one.
- For the EULA test which requires a unique user the test will unenrol the user from Turnitin at the end of the test.