### PR TITLE
Marking workflow post date change - set to -5 minutes as opposed to current time

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1785,13 +1785,13 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                         break;
                     case 0:
                         $dtpost = $dtstart;
-                        // If any grades have been released early via marking workflow, set post date to current time.
+                        // If any grades have been released early via marking workflow, set post date to have passed.
                         if ($cm->modname == 'assign' && !empty($moduledata->markingworkflow)) {
                             $gradesreleased = $DB->record_exists('assign_user_flags',
                                                             array('assignment' => $cm->instance,
                                                                     'workflowstate' => 'released'));
 
-                            $dtpost = ($gradesreleased) ? time() : strtotime('+1 month');
+                            $dtpost = ($gradesreleased) ? strtotime('-5 minutes') : strtotime('+1 month');
                         }
                         break;
                     default:


### PR DESCRIPTION
This makes a change to the scenario where grades are released early for marking workflow and the post date is set to the current time, We need to set the post date to be in the past to avoid a race condition which means an error appears when the EV opens stating the grading service is not available.