### PR TITLE
Disable Grademark for student if grade does not exist

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -945,8 +945,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                         // Check if blind marking is on and revealidentities is not set yet.
                         $blindon = (!empty($moduledata->blindmarking) && empty($moduledata->revealidentities));
 
+                        // Check if a grade exists - as $currentgradequery->grade defaults to -1.
+                        $gradeExists = false;
+                        if (isset($currentgradequery->grade)) {
+                            if ($currentgradequery->grade >= 0) {
+                                $gradeExists = true;
+                            }
+                        }
+
                         // Can grade and feedback be released to this student yet?
-                        $released = ((!$blindon) && ($gradesreleased && (!empty($plagiarismfile->gm_feedback) || isset($currentgradequery->grade))));
+                        $released = ((!$blindon) && ($gradesreleased && (!empty($plagiarismfile->gm_feedback) || $gradeExists)));
 
                         // Show link to open grademark.
                         if ($config->usegrademark && ($istutor || ($linkarray["userid"] == $USER->id && $released))

--- a/lib.php
+++ b/lib.php
@@ -946,15 +946,15 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                         $blindon = (!empty($moduledata->blindmarking) && empty($moduledata->revealidentities));
 
                         // Check if a grade exists - as $currentgradequery->grade defaults to -1.
-                        $gradeExists = false;
+                        $gradeexists = false;
                         if (isset($currentgradequery->grade)) {
                             if ($currentgradequery->grade >= 0) {
-                                $gradeExists = true;
+                                $gradeexists = true;
                             }
                         }
 
                         // Can grade and feedback be released to this student yet?
-                        $released = ((!$blindon) && ($gradesreleased && (!empty($plagiarismfile->gm_feedback) || $gradeExists)));
+                        $released = ((!$blindon) && ($gradesreleased && (!empty($plagiarismfile->gm_feedback) || $gradeexists)));
 
                         // Show link to open grademark.
                         if ($config->usegrademark && ($istutor || ($linkarray["userid"] == $USER->id && $released))


### PR DESCRIPTION
This fixes an issue where a student is able to open up Grademark before they should be able to - IE they don't yet have a grade/feedback.