### PR TITLE
Disable Grademark for student if grade does not exist

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -967,8 +967,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                         // Check if blind marking is on and revealidentities is not set yet.
                         $blindon = (!empty($moduledata->blindmarking) && empty($moduledata->revealidentities));
 
+                        // Check if a grade exists - as $currentgradequery->grade defaults to -1.
+                        $gradeexists = false;
+                        if (isset($currentgradequery->grade)) {
+                            if ($currentgradequery->grade >= 0) {
+                                $gradeexists = true;
+                            }
+                        }
+
                         // Can grade and feedback be released to this student yet?
-                        $released = ((!$blindon) && ($gradesreleased && (!empty($plagiarismfile->gm_feedback) || isset($currentgradequery->grade))));
+                        $released = ((!$blindon) && ($gradesreleased && (!empty($plagiarismfile->gm_feedback) || $gradeexists)));
 
                         // Show link to open grademark.
                         if ($config->plagiarism_turnitin_usegrademark && ($istutor || ($linkarray["userid"] == $USER->id && $released))


### PR DESCRIPTION
This fixes an issue where a student is able to open up Grademark before they should be able to - IE they don't yet have a grade/feedback.