### PR TITLE
fix errors when displaying student rubric modal in any circumstance

### DIFF
--- a/amd/src/rubric.js
+++ b/amd/src/rubric.js
@@ -19,11 +19,15 @@ define(['jquery',
             rubric: function() {
                 var that = this;
                 $('.rubric_manager_launch').on('click', function() {
-                    that.rubricCreateModal(ModalRubricManagerLaunch.TYPE);
+                    var courseid = $(this).data('courseid');
+                    var cmid = $(this).data('cmid');
+                    that.rubricCreateModal(ModalRubricManagerLaunch.TYPE, courseid, cmid);
                 });
 
                 $(document).on('click', '.rubric_view', function() {
-                    that.rubricCreateModal(ModalRubricViewLaunch.TYPE);
+                    var courseid = $(this).data('courseid');
+                    var cmid = $(this).data('cmid');
+                    that.rubricCreateModal(ModalRubricViewLaunch.TYPE, courseid, cmid);
                 });
 
                 // Show warning when changing the rubric linked to an assignment.
@@ -35,10 +39,7 @@ define(['jquery',
                     }
                 });
             },
-            rubricCreateModal: function(modalType) {
-                var courseid = ($('input[name="course"]')) ? $('input[name="course"]').val() : 0;
-                var cmid = $('input[name="coursemodule"], input[name="id"]').val() || 0;
-
+            rubricCreateModal: function(modalType, courseid, cmid) {
                 ModalFactory.create({
                     type: modalType,
                     templateContext: {

--- a/classes/turnitin_view.class.php
+++ b/classes/turnitin_view.class.php
@@ -325,6 +325,8 @@ class turnitin_view {
                     get_string('launchrubricmanager', 'plagiarism_turnitin'),
                     array(
                         'class' => 'rubric_manager_launch',
+                        'data-courseid' => $course->id,
+                        'data-cmid' => $cmid,
                         'title' => get_string('launchrubricmanager', 'plagiarism_turnitin'),
                         'id' => 'rubric_manager_form',
                         'role' => 'link',

--- a/lib.php
+++ b/lib.php
@@ -566,6 +566,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $rubricviewlink = html_writer::tag('span',
                 get_string('launchrubricview', 'plagiarism_turnitin'),
                 array('class' => 'rubric_view rubric_view_pp_launch_upload tii_tooltip',
+                    'data-courseid' => $cm->course,
+                    'data-cmid' => $cm->id,
                     'title' => get_string('launchrubricview',
                         'plagiarism_turnitin'), 'id' => 'rubric_manager_form'
                 )
@@ -1044,6 +1046,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
                             $rubricviewlink = html_writer::tag('span', '',
                                 array('class' => 'rubric_view rubric_view_pp_launch tii_tooltip',
+                                    'data-courseid' => $cm->course,
+                                    'data-cmid' => $cm->id,
                                     'title' => get_string('launchrubricview',
                                         'plagiarism_turnitin'), 'id' => 'rubric_view_launch'
                                 )


### PR DESCRIPTION
Avoid relying on spying into hidden form fields to find course and/or course module ids, and instead declare data attributes on the element where the event handler is attached.

Refs #537.