### PR TITLE
Issue#556 Set error flag if there is no file.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2933,7 +2933,7 @@ function plagiarism_turnitin_send_queued_submissions() {
     }
 
     $queueditems = $DB->get_records_select("plagiarism_turnitin_files", "statuscode = 'queued' OR statuscode = 'pending'",
-                                            null, '', '*', 0, PLAGIARISM_TURNITIN_CRON_SUBMISSIONS_LIMIT);
+                                            null, 'lastmodified', '*', 0, PLAGIARISM_TURNITIN_CRON_SUBMISSIONS_LIMIT);
 
     // Submit each file individually to Turnitin.
     foreach ($queueditems as $queueditem) {

--- a/lib.php
+++ b/lib.php
@@ -3054,7 +3054,7 @@ function plagiarism_turnitin_send_queued_submissions() {
                         plagiarism_turnitin_activitylog('File not found for submission: '.$queueditem->id, 'PP_NO_FILE');
                         mtrace('File not found for submission. Identifier: '.$queueditem->id);
                         $errorcode = 9;
-                        continue 2;
+                        break;
                     }
 
                     $title = $file->get_filename();
@@ -3067,7 +3067,7 @@ function plagiarism_turnitin_send_queued_submissions() {
                         mtrace($e);
                         mtrace('File content not found on submission. Identifier: '.$queueditem->identifier);
                         $errorcode = 9;
-                        continue 2;
+                        break;
                     }
                 } else {
                     // Get the actual text content for a submission.


### PR DESCRIPTION
For fixing the issue #556 
How to replicate the issue.

1. A student submit assignment with file.
2. The student remove the submission.
3. The schedule task says 'no file to submit' because there is a record in mdl_plagiarism_turnitin_files but not in mdl_files.
4. If the student doesn't submit file again, the record is in the queue forever, because the status remains 'queued'.

This change will update the statuscode to 'error' so the schedule task will not pick up the record anymore.