### PR TITLE
Fix #591 - Cache activity settings correctly when disabled.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -686,8 +686,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
 
         // Retrieve the plugin settings for this module.
-        static $plagiarismsettings;
-        if (empty($plagiarismsettings)) {
+        static $plagiarismsettings = null;
+        if (is_null($plagiarismsettings)) {
             $plagiarismsettings = $this->get_settings($linkarray["cmid"]);
         }
 


### PR DESCRIPTION
when an activity does not use Turnitin, this causes 2 queries per user that is displayed on the page - so if we are showing 1000 users it results in 2000 db queries that aren't needed.