### PR TITLE
ISSUE_604: Optional GradeMark grade import

### DIFF
--- a/classes/turnitin_view.class.php
+++ b/classes/turnitin_view.class.php
@@ -215,6 +215,11 @@ class turnitin_view {
             $mform->addElement('select', 'use_turnitin', get_string("useturnitin", "plagiarism_turnitin"), $options);
             $this->lock($mform, $location, $locks);
 
+            $mform->addElement('select', 'plagiarism_import_grades', get_string("importgrades", "plagiarism_turnitin"), $options);
+            $this->lock($mform, $location, $locks);
+            $mform->addHelpButton('plagiarism_import_grades', 'importgrades', 'plagiarism_turnitin');
+            $mform->setDefault('plagiarism_import_grades', 1);
+
             $mform->addElement('select', 'plagiarism_show_student_report', get_string("studentreports", "plagiarism_turnitin"), $options);
             $this->lock($mform, $location, $locks);
             $mform->addHelpButton('plagiarism_show_student_report', 'studentreports', 'plagiarism_turnitin');

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -102,6 +102,8 @@ $string['turnitinppulapre'] = 'To submit a file to Turnitin you must first accep
 $string['noscriptula'] = '(As you do not have javascript enabled you will have to manually refresh this page before you can make a submission after accepting the Turnitin User Agreement)';
 $string['filedoesnotexist'] = 'File has been deleted';
 $string['reportgenspeed_resubmission'] = 'You have already submitted a paper to this assignment and a Similarity Report was generated for your submission. If you choose to resubmit your paper, your earlier submission will be replaced and a new report will be generated. After {$a->num_resubmissions} resubmissions, you will need to wait {$a->num_hours} hours after a resubmission to see a new Similarity Report.';
+$string['importgrades'] = 'Import grades';
+$string['importgrades_help'] = 'Import grades from Turnitin GradeMark. You may wish to turn this off if your Moodle grade scale is not 1-100';
 
 // Plugin settings.
 $string['config'] = 'Configuration';

--- a/lib.php
+++ b/lib.php
@@ -97,7 +97,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      * @return array of settings fields.
      */
     public function get_settings_fields() {
-        return array('use_turnitin', 'plagiarism_show_student_report', 'plagiarism_draft_submit',
+        return array('use_turnitin', 'plagiarism_import_grades', 'plagiarism_show_student_report', 'plagiarism_draft_submit',
             'plagiarism_allow_non_or_submissions', 'plagiarism_submitpapersto', 'plagiarism_compare_student_papers',
             'plagiarism_compare_internet', 'plagiarism_compare_journals', 'plagiarism_report_gen',
             'plagiarism_compare_institution', 'plagiarism_exclude_biblio', 'plagiarism_exclude_quoted',
@@ -1411,6 +1411,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     return true;
                 }
 
+                $plagiarismsettings = $this->get_settings($cm->id);
+                if (!$plagiarismsettings['plagiarism_import_grades']) {
+                    return true;
+                }
+
                 // Update grades, for the quiz we update marks for questions instead.
                 if ($cm->modname == "quiz") {
                     $quiz = $DB->get_record('quiz', array('id' => $cm->instance));
@@ -1999,7 +2004,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         $submissions = $DB->get_records_select(
             'plagiarism_turnitin_files',
-            'statuscode = ? 
+            'statuscode = ?
             AND ( similarityscore IS NULL OR duedate_report_refresh = 1 )
             AND ( orcapable = ? OR orcapable IS NULL ) ',
             array('success', 1),


### PR DESCRIPTION
A possible work-around for the issue raised in #604 

Allows the site admin or Instructor to disable importing grades from GradeMark. Grades are still stored in the plagiarism_turnitin_files table. It overcomes the issue of incompatible grade scales.