### PR TITLE
Quiz attempt grades may be incorrectly set

### DIFF
--- a/classes/modules/turnitin_quiz.class.php
+++ b/classes/modules/turnitin_quiz.class.php
@@ -76,7 +76,7 @@ class turnitin_quiz {
         $transaction = $DB->start_delegated_transaction();
 
         $attempt = quiz_attempt::create($attemptid);
-        $quba = question_engine::load_questions_usage_by_activity($attemptid);
+        $quba = question_engine::load_questions_usage_by_activity($attempt->get_uniqueid());
 
         // Loop through each question slot.
         foreach ($attempt->get_slots() as $slot) {

--- a/tests/modules/turnitin_quiz_test.php
+++ b/tests/modules/turnitin_quiz_test.php
@@ -1,0 +1,93 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for (some of) plagiarism/turnitin/classes/modules/turnitin_quiz.class.php.
+ *
+ * @package    plagiarism_turnitin
+ * @copyright  2017 Turnitin
+ * @copyright  2022 The University of Southern Queensland
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/plagiarism/turnitin/lib.php');
+
+/**
+ * Tests for Turnitin quiz class.
+ *
+ * @package plagiarism_turnitin
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class plagiarism_turnitin_quiz_testcase extends advanced_testcase {
+    /**
+     * Proves that essay response marks are correctly updated.
+     *
+     * @copyright 2014 Tim Hunt
+     */
+    public function test_update_mark() {
+        $this->resetAfterTest();
+
+        // Create a user, course, and quiz activity with an essay question.
+        // Lifted largely from mod_quiz_attempt_testcase.
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
+        $quiz = $generator->create_instance([
+            'course' => $course->id,
+            'grade' => 100,
+            'sumgrades' => 1,
+            'layout' => '1,0',
+        ]);
+
+        $quizobj = quiz::create($quiz->id, $user->id);
+        $quba = question_engine::make_questions_usage_by_activity('mod_quiz', $quizobj->get_context());
+        $quba->set_preferred_behaviour($quizobj->get_quiz()->preferredbehaviour);
+
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $cat = $questiongenerator->create_question_category();
+        $question = $questiongenerator->create_question('essay', null, ['category' => $cat->id]);
+        quiz_add_quiz_question($question->id, $quiz, 1, 1);   // 1 mark for the question.
+
+        // Start and finish an attempt at the quiz.
+        $timenow = time();
+        $attempt = quiz_create_attempt($quizobj, 1, false, $timenow, false, $user->id);
+        quiz_start_new_attempt($quizobj, $quba, $attempt, 1, $timenow);
+        quiz_attempt_save_started($quizobj, $quba, $attempt);
+        $attemptobj = quiz_attempt::create($attempt->id);
+        $attemptobj->process_finish($timenow, false);
+
+        // Expect no marks or grade for the attempt yet.
+        $attemptobj = quiz_attempt::create($attempt->id);
+        $this->assertEquals(0.0, $attemptobj->get_sum_marks());
+        $grade = quiz_get_best_grade($quiz, $user->id);
+        $this->assertEquals(0.0, $grade);
+
+        // Now update the grade of the essay question through the Turnitin quiz class.
+        $tiiquiz = new turnitin_quiz;
+        $answer = $attemptobj->get_question_attempt(1)->get_response_summary();
+        $identifier = sha1($answer);
+        $tiiquiz->update_mark($attempt->id, $identifier, $user->id, 75, $quiz->grade);
+
+        // Reload the attempt and check the total marks and grade are as we expect it.
+        $attemptobj = quiz_attempt::create($attempt->id);
+        $this->assertEquals(0.75, $attemptobj->get_sum_marks());
+        $grade = quiz_get_best_grade($quiz, $user->id);
+        $this->assertEquals(75.0, $grade);
+    }
+}


### PR DESCRIPTION
This bug can occur in two observed ways:

1. Worst case: by causing incorrect grades to be calculated for a student's quiz attempt, hopefully nonsensical enough to be obvious.
2. Best case: by doing nothing while logging an error in the Turnitin activity log:

    `2022-06-15 16:00:36 +1000 (API_ERROR) - There was an error when trying to get a submission from Turnitin`
    `File: /.../question/engine/datalib.php | Line: 478 | Message: Coding error detected, it must be fixed by a programmer: Failed to load questions_usage_by_activity 3 | Code: 0`

The first situation is disturbing because opening a similiarity report and closing it can be enough to corrupt students' calculated total grades without it being particularly obvious to the teacher what has happened. A Quiz regrade is then needed to bring totals back into order. This happens because `quiz_attempts` and `question_usages` table IDs likely overlap such that a given `quiz_attempt` ID is also a valid `question_usages` ID.

The second situation means that at worst Grademark-given grades are not applied the student's response.
