### PR TITLE
fix/resubmit_submission_eula

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2307,8 +2307,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $coursedata = $this->get_course_data($cm->id, $cm->course);
         $user = new turnitin_user($author, "Learner");
         $user->join_user_to_class($coursedata->turnitin_cid);
-        $eulaaccepted = ($user->useragreementaccepted == 0) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
-        if ($eulaaccepted != 1) {
+        $eula_accepted = ($user->useragreementaccepted == 0) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
+        if ($eula_accepted != 1) {
             return true;
         }
         // Check if file has been submitted before.

--- a/lib.php
+++ b/lib.php
@@ -2303,6 +2303,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $attempt = 0;
         $tiisubmissionid = null;
 
+        // If the EULA hasn't been accepted, don't save submission and don't submit to Tii
+        $coursedata = $this->get_course_data($cm->id, $cm->course);
+        $user = new turnitin_user($author, "Learner");
+        $user->join_user_to_class($coursedata->turnitin_cid);
+        $eulaaccepted = ($user->useragreementaccepted == 0) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
+        if ($eulaaccepted != 1) {
+            return true;
+        }
         // Check if file has been submitted before.
         $plagiarismfiles = plagiarism_turnitin_retrieve_successful_submissions($author, $cm->id, $identifier);
         if (count($plagiarismfiles) > 0) {


### PR DESCRIPTION
Addresses the issue where a user declines the EULA and submits a submission, then later accepts the EULA and is not able to resubmit the same paper/submission.