### PR TITLE
Fix incorrect grader for mod_assign

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1444,7 +1444,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     /**
      * Update module grade and gradebook.
      */
-    private function update_grade($cm, $submission, $userid) {
+    private function update_grade($cm, $submission, $userid, $cron = FALSE) {
         global $DB, $USER, $CFG;
         $return = true;
 
@@ -1538,7 +1538,13 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     $grade->id = $currentgrade->id;
 
                     if ($cm->modname == 'assign') {
-                        $grade->grader = $USER->id;
+                        $context = context_course::instance($cm->course);
+                        if (has_capability('mod/assign:grade', $context, $USER->id)) {
+                            // If the grade has changed and the change is not from a cron task then update the grader.
+                            if ($currentgrade->grade != $grade->grade && $cron == FALSE) {
+                                $grade->grader = $USER->id;
+                            }
+                        }
                     }
 
                     $return = $DB->update_record($table, $grade);
@@ -2129,7 +2135,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
                                 // at the moment TII doesn't support double marking so we won't synchronise grades from Grade Mark as it would destroy the workflow
                                 if (!is_null($plagiarismfile->grade) && $cm->modname != "coursework") {
-                                    $this->update_grade($cm, $readsubmission, $currentsubmission->userid);
+                                    $this->update_grade($cm, $readsubmission, $currentsubmission->userid, TRUE);
                                 }
                             }
                         } catch (Exception $e) {


### PR DESCRIPTION
Hi,

This fixes the issue of incorrect grader as explained in https://github.com/turnitin/moodle-plagiarism_turnitin/issues/644

**Summary:**

The grader of the assignment is at times showing as the student or the system admin, when the assignment was actually graded by a teacher

**Steps to reproduce:**

- Create a new assignment by teacher role mod/assign/view.php?id=xyz
-- Display Similarity Reports to Students: Yes
- Login as the student and go to the assignment view page and submit assignment
- Wait for Turntin report to show percentage for plagiarism (by running cron twice ? and waiting)
- Login as teacher, go to assignment view page click on the percentage and go to Turntin
- Click on comments and grade section to enter grade and comments
- Close window
- Go go assignment view page, wait for the page to refresh automatically and release grade
- Login as student and go to assignment view page
- Click on the percentage icon  and for the window to open in Turntin. View the grade and marker feedback by clicking the comment icon (the 3rd icon in the rightside) and close the window
- Wait for the assignment view page to refresh on its own 
- Confirm that the feedback section is showing the grader as the student 
- OR
- You will see the grader as the system admin

Regards,
Sumaiya