### PR TITLE
Submission removed observer

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -132,6 +132,20 @@ class plagiarism_turnitin_observer {
     }
 
     /**
+     * Handle the assignment submission_removed event.
+     * @param \mod_assign\event\submission_removed $event
+     */
+    public static function assignsubmission_removed(
+        \mod_assign\event\submission_removed $event) {
+        $eventdata = $event->get_data();
+        $eventdata['eventtype'] = 'submission_removed';
+        $eventdata['other']['modulename'] = 'assign';
+
+        $plugin = new plagiarism_plugin_turnitin();
+        $plugin->event_handler($eventdata);
+    }
+
+    /**
      * Observer function to handle the quiz_submitted event in mod_quiz.
      * @param \mod_quiz\event\attempt_submitted $event
      */

--- a/db/events.php
+++ b/db/events.php
@@ -43,6 +43,10 @@ $observers = array (
         'callback'  => 'plagiarism_turnitin_observer::assignsubmission_submitted'
     ),
     array(
+        'eventname' => '\mod_assign\event\submission_removed',
+        'callback'  => 'plagiarism_turnitin_observer::assignsubmission_removed'
+    ),
+    array(
         'eventname' => '\mod_coursework\event\assessable_uploaded',
         'callback'  => 'plagiarism_turnitin_observer::coursework_submitted'
     ),

--- a/lib.php
+++ b/lib.php
@@ -2585,6 +2585,17 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             }
         }
 
+        // Remove submission from Turnitin queue if it is removed from Moodle.
+        if ($eventdata['other']['modulename'] == 'assign' && $eventdata['eventtype'] == "submission_removed") {
+            $params = [
+                'cm' => $eventdata['contextinstanceid'],
+                'userid' => $eventdata['relateduserid'],
+                'itemid' => $eventdata['objectid'],
+                'statuscode' => 'queued',
+            ];
+            $DB->delete_records('plagiarism_turnitin_files', $params);
+        }
+
         // Queue every question submitted in a quiz attempt.
         if ($eventdata['eventtype'] == 'quiz_submitted') {
             $attempt = quiz_attempt::create($eventdata['objectid']);

--- a/lib.php
+++ b/lib.php
@@ -2317,6 +2317,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         if ($eula_accepted != 1) {
             return true;
         }
+
+        // Remove error submission queue if any.
+        $DB->delete_records('plagiarism_turnitin_files', [
+                'cm' => $cm->id,
+                'userid' => $author,
+                'itemid' => $itemid,
+                'statuscode' => 'error',
+            ]
+        );
+
         // Check if file has been submitted before.
         $plagiarismfiles = plagiarism_turnitin_retrieve_successful_submissions($author, $cm->id, $identifier);
         if (count($plagiarismfiles) > 0) {

--- a/version.php
+++ b/version.php
@@ -19,7 +19,7 @@
  * @copyright 2012 iParadigms LLC
  */
 
-$plugin->version = 2024072401;
+$plugin->version = 2024072402;
 
 $plugin->release = "3.5+";
 $plugin->requires = 2018051700;


### PR DESCRIPTION
This adds an observer to handle submission removal event, follow up the suggestion (number 2) by Tomo on

https://github.com/turnitin/moodle-plagiarism_turnitin/issues/556

Hi @jack-tii ,

Thanks for your note on:

https://github.com/turnitin/moodle-plagiarism_turnitin/pull/665

I have created another PR with a new branch in case (submission_removed_observer is being used)
The new branch has already rebased against 'develop'

