### PR TITLE
Fix phpunit with Moodle 4.3 and PHP 8.2.

### DIFF
--- a/tests/modules/turnitin_assign_test.php
+++ b/tests/modules/turnitin_assign_test.php
@@ -35,6 +35,12 @@ require_once($CFG->dirroot . '/mod/assign/externallib.php');
  */
 class plagiarism_turnitin_assign_testcase extends advanced_testcase {
 
+    /** @var stdClass created in setUp. */
+    protected $course;
+
+    /** @var stdClass created in setUp. */
+    protected $assign;
+
     /**
      * Create a course and assignment module instance
      */

--- a/tests/modules/turnitin_forum_test.php
+++ b/tests/modules/turnitin_forum_test.php
@@ -34,6 +34,15 @@ require_once($CFG->dirroot . '/plagiarism/turnitin/lib.php');
  */
 class plagiarism_turnitin_forum_testcase extends advanced_testcase {
 
+    /** @var stdClass created in setUp. */
+    protected $forum;
+
+    /** @var stdClass created in setUp. */
+    protected $discussion;
+
+    /** @var stdClass created in setUp. */
+    protected $post;
+
     /**
      * Create a course and forum module instance
      */


### PR DESCRIPTION
We were seeing PHPunit failures after installing this plugin into Moodle 4.3 (with PHP 8.2).

This is one way to fix it. May not be the most elegant, but I hope it is OK.

Among other things, this fixes issue #712.

I tested on Moodle 4.1 with PHP 7.4 to verify that I had not broken anything.

I hope this is helpful @carl-hostrander.