### PR TITLE
Check file size when creating TII submission

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3084,6 +3084,16 @@ function plagiarism_turnitin_send_queued_submissions() {
                         break;
                     }
 
+                    // Prevent submissions queue breaking if file is too large and a larger size limit has been set in Moodle
+                    if ($file->get_filesize() > PLAGIARISM_TURNITIN_MAX_FILE_UPLOAD_SIZE) {
+                        $errorstring = 'File with ID '.$queueditem->id.' cannot be sent to turnitin: File size is '.$file->get_filesize().
+                            ' bytes, and the max filesize that Turnitin can accept is '.PLAGIARISM_TURNITIN_MAX_FILE_UPLOAD_SIZE.' bytes.';
+                        plagiarism_turnitin_activitylog($errorstring, 'PP_FILE_TOO_LARGE');
+                        mtrace($errorstring);
+                        $errorcode = 2;
+                        break;
+                    }
+
                     $title = $file->get_filename();
                     $filename = $file->get_filename();
 


### PR DESCRIPTION
Setting a file size upload limit over 100MiB will currently allow students to submit files which will break the submission queue. This adds a missing check to the submission process to skip the file if it's over the limit.