### PR TITLE
Fix DV links not showing in forums

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2624,7 +2624,12 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $eventdata['other']['content'] = $moodlesubmission->content;
             }
 
-            $identifier = sha1($eventdata['other']['content']);
+            // If the content of the submission contains any images, these will show up as img tags
+            // At this moment (in the event handler) the src attribute of these img tags will be in the form of a full URL,
+            // but when we retrieve them later (i.e. when getting Document Viewer links) the stem will be replaced by @@PLUGINFILE@@
+            // Therefore to calculate the same hash in both places, we must perform the same replacement here
+            $content = preg_replace('~(?<=<img src=").*(?=\/[^"]+")~', '@@PLUGINFILE@@', $eventdata['other']['content']);
+            $identifier = sha1($content);
 
             // Check if content has been submitted before and return if so.
             $result = $this->queue_submission_to_turnitin(

--- a/lib.php
+++ b/lib.php
@@ -1011,8 +1011,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                         $released = ((!$blindon) && ($gradesreleased && (!empty($plagiarismfile->gm_feedback) || $gradeexists)));
 
                         // Show link to open grademark.
-                        if ($config->plagiarism_turnitin_usegrademark && ($istutor || ($linkarray["userid"] == $USER->id && $released))
-                                 && !empty($gradeitem)) {
+                        if ($config->plagiarism_turnitin_usegrademark && ($istutor || ($linkarray["userid"] == $USER->id && $released))) {
 
                             // Output grademark icon.
                             $gmicon = html_writer::tag('div', $OUTPUT->pix_icon('icon-edit',


### PR DESCRIPTION
This PR addresses 2 bugs which are preventing document viewer links from showing as they should.

Firstly, not all submissions that we want to be able to show similarity reports for have an associated grade item, therefore I removed the check that a grade item must always exist in order to display the link to the document viewer for a submission.

Secondly, the entire links area including both the document viewer link and submission status does not show up when an image is embedded in a forum submission. This is because the hash we are using as an identifier to look up the file does not match.

The identifier is initially created by hashing the entire submission content. However, when we look up the item later, any URLs in the submission contents will have been changed to use @@PLUGINFILE@@ so that they can be served by the Moodle file API. This means the content is different, so the hashes do not match. To resolve this I added an extra lookup when initially generating the hash, so that we are creating the hash based on the same content string both times.