### PR TITLE
Optimising DB calls in cron

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2041,7 +2041,12 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
           ['success', 1]
         );
 
-        echo('$submissions: ' . json_encode($submissions, JSON_PRETTY_PRINT) . "\n");
+        $modulesettings = [];
+        foreach ($submissions as $tiisubmission) {
+          if (!array_key_exists($tiisubmission->cm, $modulesettings)) {
+            $modulesettings[$tiisubmission->cm] = $this->get_settings($tiisubmission->cm);
+          }
+        }
 
         // Add submission ids to the request.
         foreach ($submissions as $tiisubmission) {
@@ -2054,20 +2059,19 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             }
 
             if (!isset($reportsexpected[$tiisubmission->cm])) {
-                $plagiarismsettings = $this->get_settings($tiisubmission->cm);
 
                 $reportsexpected[$tiisubmission->cm] = 1;
 
-                if (!isset($plagiarismsettings['plagiarism_compare_institution'])) {
-                    $plagiarismsettings['plagiarism_compare_institution'] = 0;
+                if (!isset($modulesettings[$tiisubmission->cm]['plagiarism_compare_institution'])) {
+                    $modulesettings[$tiisubmission->cm]['plagiarism_compare_institution'] = 0;
                 }
 
                 // Don't add the submission to the request if module settings mean we will not get a report back.
-                if (array_key_exists('plagiarism_compare_student_papers', $plagiarismsettings) &&
-                    $plagiarismsettings['plagiarism_compare_student_papers'] == 0 &&
-                    $plagiarismsettings['plagiarism_compare_internet'] == 0 &&
-                    $plagiarismsettings['plagiarism_compare_journals'] == 0 &&
-                    $plagiarismsettings['plagiarism_compare_institution'] == 0) {
+                if (array_key_exists('plagiarism_compare_student_papers', $modulesettings[$tiisubmission->cm]) &&
+                    $modulesettings[$tiisubmission->cm]['plagiarism_compare_student_papers'] == 0 &&
+                    $modulesettings[$tiisubmission->cm]['plagiarism_compare_internet'] == 0 &&
+                    $modulesettings[$tiisubmission->cm]['plagiarism_compare_journals'] == 0 &&
+                    $modulesettings[$tiisubmission->cm]['plagiarism_compare_institution'] == 0) {
                     $reportsexpected[$tiisubmission->cm] = 0;
                 }
             }

--- a/lib.php
+++ b/lib.php
@@ -2015,18 +2015,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $submissionids = array();
         $reportsexpected = array();
         $assignmentids = array();
-
-        /*
-        $submissions = $DB->get_records_select(
-            'plagiarism_turnitin_files',
-            'statuscode = ?
-            AND ( similarityscore IS NULL OR duedate_report_refresh = 1 )
-            AND ( orcapable = ? OR orcapable IS NULL ) ',
-            array('success', 1),
-            'externalid DESC'
-        );
-        */
-
+        
         $submissions = $DB->get_records_sql(
           'SELECT PTF.*, 
           CM.instance AS instance,

--- a/lib.php
+++ b/lib.php
@@ -2080,16 +2080,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             if ($reportsexpected[$tiisubmission->cm] == 1) {
                 $submissionids[] = $tiisubmission->externalid;
 
-                // If submission is added to the request, add the corresponding assign id in the assignids array.
-                $moduleturnitinconfig = $DB->get_record('plagiarism_turnitin_config',
-                    array(
-                        'cm' => $tiisubmission->cm,
-                        'name' => 'turnitin_assignid'
-                    )
-                );
-
-                if (!isset(array_flip($assignmentids)[$moduleturnitinconfig->value])) {
-                    $assignmentids[] = $moduleturnitinconfig->value;
+                if (!isset(array_flip($assignmentids)[$modulesettings[$tiisubmission->cm]->turnitin_assignid])) {
+                    $assignmentids[] = $modulesettings[$tiisubmission->cm]->turnitin_assignid;
                 }
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -2045,54 +2045,49 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Add submission ids to the request.
         foreach ($submissions as $tiisubmission) {
+            // Updates the db field 'duedate_report_refresh' if the due date has passed within the last twenty four hours.
+            $moduledata = $DB->get_record($tiisubmission->modname, array('id' => $tiisubmission->instance));
+            $now = strtotime('now');
+            $dtdue = (!empty($moduledata->duedate)) ? $moduledata->duedate : 0;
+            if ($tiisubmission->duedate_report_refresh != 1 && $now >= $dtdue && $now < strtotime('+1 day', $dtdue)) {
+                $this->set_duedate_report_refresh($tiisubmission->id, 1);
+            }
 
-            // Only add the submission to the request if the module still exists.
-            // if ($cm = get_coursemodule_from_id('', $tiisubmission->cm)) {
+            if (!isset($reportsexpected[$tiisubmission->cm])) {
+                $plagiarismsettings = $this->get_settings($tiisubmission->cm);
 
-                // Updates the db field 'duedate_report_refresh' if the due date has passed within the last twenty four hours.
-                $moduledata = $DB->get_record($tiisubmission->modname, array('id' => $tiisubmission->instance));
-                $now = strtotime('now');
-                $dtdue = (!empty($moduledata->duedate)) ? $moduledata->duedate : 0;
-                if ($tiisubmission->duedate_report_refresh != 1 && $now >= $dtdue && $now < strtotime('+1 day', $dtdue)) {
-                    $this->set_duedate_report_refresh($tiisubmission->id, 1);
+                $reportsexpected[$tiisubmission->cm] = 1;
+
+                if (!isset($plagiarismsettings['plagiarism_compare_institution'])) {
+                    $plagiarismsettings['plagiarism_compare_institution'] = 0;
                 }
 
-                if (!isset($reportsexpected[$tiisubmission->cm])) {
-                    $plagiarismsettings = $this->get_settings($tiisubmission->cm);
-
-                    $reportsexpected[$tiisubmission->cm] = 1;
-
-                    if (!isset($plagiarismsettings['plagiarism_compare_institution'])) {
-                        $plagiarismsettings['plagiarism_compare_institution'] = 0;
-                    }
-
-                    // Don't add the submission to the request if module settings mean we will not get a report back.
-                    if (array_key_exists('plagiarism_compare_student_papers', $plagiarismsettings) &&
-                        $plagiarismsettings['plagiarism_compare_student_papers'] == 0 &&
-                        $plagiarismsettings['plagiarism_compare_internet'] == 0 &&
-                        $plagiarismsettings['plagiarism_compare_journals'] == 0 &&
-                        $plagiarismsettings['plagiarism_compare_institution'] == 0) {
-                        $reportsexpected[$tiisubmission->cm] = 0;
-                    }
+                // Don't add the submission to the request if module settings mean we will not get a report back.
+                if (array_key_exists('plagiarism_compare_student_papers', $plagiarismsettings) &&
+                    $plagiarismsettings['plagiarism_compare_student_papers'] == 0 &&
+                    $plagiarismsettings['plagiarism_compare_internet'] == 0 &&
+                    $plagiarismsettings['plagiarism_compare_journals'] == 0 &&
+                    $plagiarismsettings['plagiarism_compare_institution'] == 0) {
+                    $reportsexpected[$tiisubmission->cm] = 0;
                 }
+            }
 
-                // Only add the submission to the request if we are expecting an originality report.
-                if ($reportsexpected[$tiisubmission->cm] == 1) {
-                    $submissionids[] = $tiisubmission->externalid;
+            // Only add the submission to the request if we are expecting an originality report.
+            if ($reportsexpected[$tiisubmission->cm] == 1) {
+                $submissionids[] = $tiisubmission->externalid;
 
-                    // If submission is added to the request, add the corresponding assign id in the assignids array.
-                    $moduleturnitinconfig = $DB->get_record('plagiarism_turnitin_config',
-                        array(
-                            'cm' => $tiisubmission->cm,
-                            'name' => 'turnitin_assignid'
-                        )
-                    );
+                // If submission is added to the request, add the corresponding assign id in the assignids array.
+                $moduleturnitinconfig = $DB->get_record('plagiarism_turnitin_config',
+                    array(
+                        'cm' => $tiisubmission->cm,
+                        'name' => 'turnitin_assignid'
+                    )
+                );
 
-                    if (!isset(array_flip($assignmentids)[$moduleturnitinconfig->value])) {
-                        $assignmentids[] = $moduleturnitinconfig->value;
-                    }
+                if (!isset(array_flip($assignmentids)[$moduleturnitinconfig->value])) {
+                    $assignmentids[] = $moduleturnitinconfig->value;
                 }
-            // }
+            }
         }
 
         $validatedsubmissions = $this->check_local_submission_state($assignmentids, $submissionids);

--- a/lib.php
+++ b/lib.php
@@ -2059,7 +2059,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
                 if (!isset($reportsexpected[$tiisubmission->cm])) {
                     $plagiarismsettings = $this->get_settings($tiisubmission->cm);
-                    $reportsexpected[$tiisubmission->cm] = 1;
+
+                    // TODO: DON'T COMMIT THIS! Change this back!
+                    // $reportsexpected[$tiisubmission->cm] = 1;
 
                     if (!isset($plagiarismsettings['plagiarism_compare_institution'])) {
                         $plagiarismsettings['plagiarism_compare_institution'] = 0;
@@ -2175,9 +2177,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Sets the duedate_report_refresh flag for each processed submission to 2 to prevent them being processed again in the next cron run.
         foreach ($submissions as $tiisubmission) {
-            if ($cm = get_coursemodule_from_id('', $tiisubmission->cm)) {
-                $this->set_duedate_report_refresh($tiisubmission->id, 2);
-            }
+            $this->set_duedate_report_refresh($tiisubmission->id, 2);
         }
 
         return true;

--- a/lib.php
+++ b/lib.php
@@ -2053,15 +2053,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $moduledata = $DB->get_record($tiisubmission->modname, array('id' => $tiisubmission->instance));
                 $now = strtotime('now');
                 $dtdue = (!empty($moduledata->duedate)) ? $moduledata->duedate : 0;
-                if ($now >= $dtdue && $now < strtotime('+1 day', $dtdue)) {
+                if ($tiisubmission->duedate_report_refresh != 1 && $now >= $dtdue && $now < strtotime('+1 day', $dtdue)) {
                     $this->set_duedate_report_refresh($tiisubmission->id, 1);
                 }
 
                 if (!isset($reportsexpected[$tiisubmission->cm])) {
                     $plagiarismsettings = $this->get_settings($tiisubmission->cm);
 
-                    // TODO: DON'T COMMIT THIS! Change this back!
-                    // $reportsexpected[$tiisubmission->cm] = 1;
+                    $reportsexpected[$tiisubmission->cm] = 1;
 
                     if (!isset($plagiarismsettings['plagiarism_compare_institution'])) {
                         $plagiarismsettings['plagiarism_compare_institution'] = 0;


### PR DESCRIPTION
Addresses #515

Currently we are doing a whole load of unnecessary DB reads when running the cron job to send queued files to tii.

This PR does 2 things:

1. Fetch the coursemodule instance and module name upfront instead of in a loop. This eliminates the need to call get_coursemodule_from_id for each submission, removing 4 DB reads per submission.
2. Cache module settings up front - we only need one DB read per module for this, not one per submission. Therefore we can fetch them all in advance and read them from an array later.