### PR TITLE
Check for capabilities at the activity level

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -726,10 +726,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $moduleclass = "turnitin_".$cm->modname;
         $moduleobject = new $moduleclass;
 
-        // Work out if logged in user is a tutor on this module.
+        // Work out if logged in user is a tutor on this activity module.
         static $istutor;
         if (empty($istutor)) {
-            $istutor = $moduleobject->is_tutor($context);
+            $ctx_module = context_module::instance($cm->id);
+            $istutor = $moduleobject->is_tutor($ctx_module);
         }
 
         // Define the timestamp for updating Peermark Assignments.


### PR DESCRIPTION
Currently we have a bug where if a student is assigned the role of teacher on a specific activity, they are unable to view TII report scores. This is because we are checking for teacher permissions at the course level only.

Resolves #608