### PR TITLE
Add before_standard_top_of_body_html hooks

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package   plagiarism_turnitin
+ * @copyright 2012 iParadigms LLC
+ */
+
+namespace plagiarism_turnitin;
+
+defined('MOODLE_INTERNAL') || die();
+
+use core\hook\output\before_standard_top_of_body_html_generation;
+
+class hook_callbacks {
+
+    /**
+     * Hook callback to insert a chunk of html at the start of an html document.
+     *
+     * @param before_standard_top_of_body_html_generation $hook
+     */
+    public static function before_standard_top_of_body_html_generation(before_standard_top_of_body_html_generation $hook): void {
+        $output = '<div class="turnitin_score_refresh_alert" id="turnitin_score_refresh_alert">' . get_string('turnitin_score_refresh_alert', 'plagiarism_turnitin') . '</div>';
+        $hook->add_html($output);
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -1,0 +1,30 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package   plagiarism_turnitin
+ * @copyright 2012 iParadigms LLC
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_standard_top_of_body_html_generation::class,
+        'callback' => [plagiarism_turnitin\hook_callbacks::class, 'before_standard_top_of_body_html_generation'],
+        'priority' => 0,
+    ],
+];

--- a/lib.php
+++ b/lib.php
@@ -190,17 +190,17 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     }
 
     /**
-     * This function is called from the inbox in mod assign.
+     * Callback to add a chunk of HTML to the top of the body
      * This will alert the user to refresh the assignment when there has been a change in scores.
-     *
-     * @param $course - Course the module is part of
-     * @param $cm - Course module
+     * Deprecated in Moodle 4.4+, for these versions we use the hooks api instead. See
+     * classes/hook_callbacks.php and db/hooks.php
      * @return string
      */
-    public function update_status($course, $cm) {
+    public function plagiarism_turnitin_before_standard_top_of_body_html() {
         return html_writer::div(get_string('turnitin_score_refresh_alert', 'plagiarism_turnitin'),
             'turnitin_score_refresh_alert', array('id' => 'turnitin_score_refresh_alert'));
     }
+
     /**
      * Check if plugin has been configured with Turnitin account details.
      * @return boolean whether the plugin is configured for Turnitin.


### PR DESCRIPTION
update_status was deprecated in Moodle 4.0 and will be removed completely in Moodle 4.5
This functionality was replaced in Moodle 4.0 by callback before_standard_top_of_body_html. In Moodle 4.4 it was replaced again, this time by the hooks API.
Since we presently support versions 4.1+, we have to support both approaches.