### PR TITLE
Add missing properties for LTI.php

### DIFF
--- a/vendor/Integrations/phpsdk-package/src/LTI.php
+++ b/vendor/Integrations/phpsdk-package/src/LTI.php
@@ -33,6 +33,8 @@ class LTI extends OAuthSimple {
     protected $proxypassword;
     protected $proxybypass;
     protected $sslcertificate;
+    protected $integrationversion;
+    protected $pluginversion;
 
     public function __construct( $apibaseurl ) {
         $this->setApiBaseUrl( $apibaseurl );


### PR DESCRIPTION
Resolves deprecation warnings under PHP 8.2