### PR TITLE
Truncate assignment title in TFS

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1766,7 +1766,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         if ( mb_strlen( $moduledata->name, 'UTF-8' ) > 80 ) {
             $title = mb_substr( $moduledata->name, 0, 80, 'UTF-8' ) . "...";
         }
-        $assignment->setTitle( $title . " (Moodle PP)" );
+        $assignment->setTitle($title);
 
         // Configure repository setting.
         $reposetting = (isset($modulepluginsettings["plagiarism_submitpapersto"])) ? $modulepluginsettings["plagiarism_submitpapersto"] : 1;


### PR DESCRIPTION
This PR removes the "(Moodle PP)" from the end of the assignment title in TFS. This is so that the assignment will have the same name in the LTI assignment copy tool as the name that the user sees within Moodle.