### PR TITLE
Add version check for hooks api

### DIFF
--- a/db/hooks.php
+++ b/db/hooks.php
@@ -21,10 +21,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$callbacks = [
+if ($CFG->version >= 2024042200) {
+  $callbacks = [
     [
         'hook' => \core\hook\output\before_standard_top_of_body_html_generation::class,
         'callback' => [plagiarism_turnitin\hook_callbacks::class, 'before_standard_top_of_body_html_generation'],
         'priority' => 0,
     ],
-];
+  ];
+}


### PR DESCRIPTION
Resolves some warnings in Moodle versions < 4.4