### PR TITLE
Don't create course when assignment settings page loaded

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -312,7 +312,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             if ($PAGE->pagetype != 'course-editbulkcompletion' &&
                 $PAGE->pagetype != 'course-editdefaultcompletion' &&
                 $PAGE->pagetype != 'course-defaultcompletion') {
-                // Create/Edit course in Turnitin and join user to class.
+                // Check for existing settings and add the form
                 $course = turnitin_assignment::get_course_data($COURSE->id, "site");
                 $turnitinview->add_elements_to_settings_form($mform, $course, "activity", $modulename, $cmid, $plagiarismvalues["plagiarism_rubric"]);
             }

--- a/lib.php
+++ b/lib.php
@@ -313,7 +313,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $PAGE->pagetype != 'course-editdefaultcompletion' &&
                 $PAGE->pagetype != 'course-defaultcompletion') {
                 // Create/Edit course in Turnitin and join user to class.
-                $course = $this->get_course_data($cmid, $COURSE->id);
+                $course = turnitin_assignment::get_course_data($COURSE->id, "site");
                 $turnitinview->add_elements_to_settings_form($mform, $course, "activity", $modulename, $cmid, $plagiarismvalues["plagiarism_rubric"]);
             }
             $settingsdisplayed = true;


### PR DESCRIPTION
This fixes a bug where courses are being created in TFS when the plugin is not enabled for an activity module within that course. This is inflating user counts and it's important for reporting that we get this patched.

The problem basically comes down to the fact that the PHP logic to create a course in TFS is wrapped up inside the logic that queries course data.

Previously when creating an activity module, loading the plugin settings form would make a call to get_course_data, which would then create the course in TFS. This meant that TFS courses could be erroneously created even without actually creating the Moodle activity module - just opening the settings and then backing out without saving was enough to trigger this behaviour.

I have removed this logic and replaced it with the equivalent call to just query the local database to find the current settings (if any).

A side effect of this approach is that course creation in TFS is now deferred until the course has been interacted with in some way. In other words, if you open TFS you won't see the course until you submit to an assignment with PP enabled, open the peermark viewer, attach a TFS rubric, etc.