### PR TITLE
Change rubric ID to integer

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -346,7 +346,7 @@ switch ($action) {
             $instructor->set_user_values_from_tii();
             $instructorrubrics = $instructor->get_instructor_rubrics();
 
-            $options = array('' => get_string('norubric', 'plagiarism_turnitin')) + $instructorrubrics;
+            $options = array(0 => get_string('norubric', 'plagiarism_turnitin')) + $instructorrubrics;
 
             // Get rubrics that are shared on the Turnitin account.
             $turnitinclass = new turnitin_class($courseid);

--- a/lib.php
+++ b/lib.php
@@ -1812,7 +1812,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         // Otherwise, the Turnitin setting is incompatible with Moodle due to multiple files and resubmission rules.
         $assignment->setLateSubmissionsAllowed(1);
         $assignment->setMaxGrade(0);
-        $assignment->setRubricId((!empty($modulepluginsettings["plagiarism_rubric"])) ? $modulepluginsettings["plagiarism_rubric"] : '');
+        $assignment->setRubricId((!empty($modulepluginsettings["plagiarism_rubric"])) ? $modulepluginsettings["plagiarism_rubric"] : 0);
 
         if (!empty($moduledata->grade)) {
             $assignment->setMaxGrade(($moduledata->grade < 0) ? 100 : (int)$moduledata->grade);


### PR DESCRIPTION
We are currently sending a blank string as the rubric ID to TFS instead of the integer 0 when no rubric is attached to an assignment. This fixes a bug where it is impossible to detach rubrics from PP TFS assignments.