### PR TITLE
Change name of settings form headers

### DIFF
--- a/classes/turnitin_view.class.php
+++ b/classes/turnitin_view.class.php
@@ -128,12 +128,12 @@ class turnitin_view {
                             2 => get_string('excludepercent', 'plagiarism_turnitin'));
 
         if ($location == "defaults") {
-            $mform->addElement('header', 'plugin_header', get_string('turnitindefaults', 'plagiarism_turnitin'));
+            $mform->addElement('header', 'turnitin_plugin_header', get_string('turnitindefaults', 'plagiarism_turnitin'));
             $mform->addElement('html', get_string("defaultsdesc", "plagiarism_turnitin"));
         }
 
         if ($location != "defaults") {
-            $mform->addElement('header', 'plugin_header', get_string('turnitinpluginsettings', 'plagiarism_turnitin'));
+            $mform->addElement('header', 'turnitin_plugin_header', get_string('turnitinpluginsettings', 'plagiarism_turnitin'));
 
             // Add in custom Javascript and CSS.
             $PAGE->requires->jquery_plugin('ui');


### PR DESCRIPTION
Currently if both the Plagiarism Plugin and Integrity Plugin are installed clicking the collapsing header in the settings menu for one of them will cause both to open. This is because both have the same name - 'plugin_header'. This PR changes the name of the header for this plugin so each name is unique and each settings menu can be opened separately.