### PR TITLE
Add version check for mod_quiz namespace

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2510,7 +2510,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      * @return bool result
      */
     public function event_handler($eventdata) {
-        global $CFG, $DB;
+        global $DB;
 
         $result = true;
 

--- a/lib.php
+++ b/lib.php
@@ -2510,7 +2510,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      * @return bool result
      */
     public function event_handler($eventdata) {
-        global $DB;
+        global $CFG, $DB;
 
         $result = true;
 
@@ -2601,7 +2601,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Queue every question submitted in a quiz attempt.
         if ($eventdata['eventtype'] == 'quiz_submitted') {
-            $attempt = mod_quiz\quiz_attempt::create($eventdata['objectid']);
+            // Namespace was changed in Moodle 4.2.
+            // TODO: We can delete the else block here when we no longer support Moodle 4.1
+            if ($CFG->version >= 2023042411) {
+                $attempt = mod_quiz\quiz_attempt::create($eventdata['objectid']);
+            }
+            else {
+              $attempt = quiz_attempt::create($queueditem->itemid);
+            }
             foreach ($attempt->get_slots() as $slot) {
                 $qa = $attempt->get_question_attempt($slot);
                 if ($qa->get_question()->get_type_name() != 'essay') {
@@ -3203,7 +3210,14 @@ function plagiarism_turnitin_send_queued_submissions() {
 
                 require_once($CFG->dirroot . '/mod/quiz/locallib.php');
                 try {
-                    $attempt = mod_quiz\quiz_attempt::create($queueditem->itemid);
+                    // Namespace was changed in Moodle 4.2.
+                    // TODO: We can delete the else block here when we no longer support Moodle 4.1
+                    if ($CFG->version >= 2023042411) {
+                        $attempt = mod_quiz\quiz_attempt::create($eventdata['objectid']);
+                    }
+                    else {
+                      $attempt = quiz_attempt::create($queueditem->itemid);
+                    }
                 } catch (Exception $e) {
                     plagiarism_turnitin_activitylog(get_string('errorcode14', 'plagiarism_turnitin'), "PP_NO_ATTEMPT");
                     $errorcode = 14;

--- a/lib.php
+++ b/lib.php
@@ -2602,6 +2602,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         // Queue every question submitted in a quiz attempt.
         if ($eventdata['eventtype'] == 'quiz_submitted') {
 
+            require_once($CFG->dirroot . '/mod/quiz/locallib.php');
             if (class_exists('\mod_quiz\quiz_attempt')) {
                 $quizattemptclass = '\mod_quiz\quiz_attempt';
             } else {

--- a/lib.php
+++ b/lib.php
@@ -2607,7 +2607,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $attempt = mod_quiz\quiz_attempt::create($eventdata['objectid']);
             }
             else {
-              $attempt = quiz_attempt::create($queueditem->itemid);
+                $attempt = quiz_attempt::create($eventdata['objectid']);
             }
             foreach ($attempt->get_slots() as $slot) {
                 $qa = $attempt->get_question_attempt($slot);
@@ -3213,10 +3213,10 @@ function plagiarism_turnitin_send_queued_submissions() {
                     // Namespace was changed in Moodle 4.2.
                     // TODO: We can delete the else block here when we no longer support Moodle 4.1
                     if ($CFG->version >= 2023042411) {
-                        $attempt = mod_quiz\quiz_attempt::create($eventdata['objectid']);
+                        $attempt = mod_quiz\quiz_attempt::create($queueditem->itemid);
                     }
                     else {
-                      $attempt = quiz_attempt::create($queueditem->itemid);
+                        $attempt = quiz_attempt::create($queueditem->itemid);
                     }
                 } catch (Exception $e) {
                     plagiarism_turnitin_activitylog(get_string('errorcode14', 'plagiarism_turnitin'), "PP_NO_ATTEMPT");

--- a/lib.php
+++ b/lib.php
@@ -2601,14 +2601,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Queue every question submitted in a quiz attempt.
         if ($eventdata['eventtype'] == 'quiz_submitted') {
-            // Namespace was changed in Moodle 4.2.
-            // TODO: We can delete the else block here when we no longer support Moodle 4.1
-            if ($CFG->version >= 2023042411) {
-                $attempt = mod_quiz\quiz_attempt::create($eventdata['objectid']);
+
+            if (class_exists('\mod_quiz\quiz_attempt')) {
+                $quizattemptclass = '\mod_quiz\quiz_attempt';
+            } else {
+                $quizattemptclass = 'quiz_attempt';
             }
-            else {
-                $attempt = quiz_attempt::create($eventdata['objectid']);
-            }
+            $attempt = $quizattemptclass::create($eventdata['objectid']);
+            
             foreach ($attempt->get_slots() as $slot) {
                 $qa = $attempt->get_question_attempt($slot);
                 if ($qa->get_question()->get_type_name() != 'essay') {
@@ -3210,14 +3210,13 @@ function plagiarism_turnitin_send_queued_submissions() {
 
                 require_once($CFG->dirroot . '/mod/quiz/locallib.php');
                 try {
-                    // Namespace was changed in Moodle 4.2.
-                    // TODO: We can delete the else block here when we no longer support Moodle 4.1
-                    if ($CFG->version >= 2023042411) {
-                        $attempt = mod_quiz\quiz_attempt::create($queueditem->itemid);
+                    if (class_exists('\mod_quiz\quiz_attempt')) {
+                        $quizattemptclass = '\mod_quiz\quiz_attempt';
+                    } else {
+                        $quizattemptclass = 'quiz_attempt';
                     }
-                    else {
-                        $attempt = quiz_attempt::create($queueditem->itemid);
-                    }
+                    $attempt = $quizattemptclass::create($queueditem->itemid);
+
                 } catch (Exception $e) {
                     plagiarism_turnitin_activitylog(get_string('errorcode14', 'plagiarism_turnitin'), "PP_NO_ATTEMPT");
                     $errorcode = 14;


### PR DESCRIPTION
In Moodle 4.2 the PHP class quiz_attempt was moved out of the global namespace and into mod_quiz

Currently our plugin works for newer Moodle versions (4.2+) but we need to support Moodle 4.1. Therefore we need to add a check for the current Moodle version, and use the namespace version on Moodle 4.2+.