### PR TITLE
Fix call to non-existent moodle_database::create_record method

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1961,7 +1961,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 } else {
                     // Otherwise create rubric entry for this module.
                     $rubricfield->config_hash = $rubricfield->cm."_".$rubricfield->name;
-                    $DB->create_record('plagiarism_turnitin_config', $rubricfield);
+                    $DB->insert_record('plagiarism_turnitin_config', $rubricfield);
                 }
             }
             catch (Exception $e) {


### PR DESCRIPTION
This can be reproduced most directly by:

1. Creating an Assignment activity, activating Turnitin and Grademark, and setting a Turnitin rubric.
2. Submit for a student in the activity, then run cron until the submission is transmitted.
3. In your database client, run: `DELETE FROM {plagiarism_turnitin_config} WHERE cm = :activitycmid AND name = 'plagiarism_rubric'`
4. Back in the Assignment activity, view the Grademark interface for the student submission, set a grade, then close the tab.
5. Without this fix, you ought to observe this captured in your PHP log:
```
Default exception handler: Exception - Call to undefined method pgsql_native_moodle_database::create_record()
Debug:
Error code: generalexceptionmessage
* line 1965 of /plagiarism/turnitin/lib.php: Error thrown
* line 97 of /plagiarism/turnitin/ajax.php: call to plagiarism_plugin_turnitin->update_rubric_from_tii()
```