### PR TITLE
Using question_attempt ID for identifier

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -775,7 +775,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $plagiarismfile = null;
             $moodlesubmission = $DB->get_record('assign_submission', array('id' => $itemid), 'id, groupid');
             if ((!empty($moodlesubmission->groupid)) && ($cm->modname == "assign")) {
-                $plagiarismfiles = $DB->get_records('plagiarism_turnitin_files', ['itemid' => $itemid, 'cm' => $cm->id,
+                $plagiarismfiles = $DB->get_records_list('plagiarism_turnitin_files', ['itemid' => $itemid, 'cm' => $cm->id,
                     'identifier' => [$identifier, $oldidentifier]],  // Check both identifiers for backwards compatibility.
                     'lastmodified DESC', '*', 0, 1);
                 $plagiarismfile = reset($plagiarismfiles);

--- a/lib.php
+++ b/lib.php
@@ -736,6 +736,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $this->load_page_components();
 
             $identifier = '';
+            $oldidentifier = '';
             $itemid = 0;
 
             // Get File or Content information.
@@ -753,7 +754,13 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     $submissiontype = 'quiz_answer';
                 }
                 $content = $moduleobject->set_content($linkarray, $cm);
-                $identifier = ($submissiontype === 'quiz_answer') ? sha1($linkarray['area']) : sha1($content);
+                if ($submissiontype === 'quiz_answer') {
+                  $identifier = sha1($linkarray['area']);
+                  $oldidentifier = sha1($content.$linkarray["itemid"]);
+                }
+                else {
+                  $identifier = sha1($content);
+                }
             }
 
             // Group submissions where all students have to submit sets userid to 0.
@@ -768,7 +775,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $plagiarismfile = null;
             $moodlesubmission = $DB->get_record('assign_submission', array('id' => $itemid), 'id, groupid');
             if ((!empty($moodlesubmission->groupid)) && ($cm->modname == "assign")) {
-                $plagiarismfiles = $DB->get_records('plagiarism_turnitin_files', ['itemid' => $itemid, 'cm' => $cm->id, 'identifier' => $identifier],
+                $plagiarismfiles = $DB->get_records('plagiarism_turnitin_files', ['itemid' => $itemid, 'cm' => $cm->id,
+                    'identifier' => [$identifier, $oldidentifier]],  // Check both identifiers for backwards compatibility.
                     'lastmodified DESC', '*', 0, 1);
                 $plagiarismfile = reset($plagiarismfiles);
                 $author = $plagiarismfile->userid;

--- a/lib.php
+++ b/lib.php
@@ -754,6 +754,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 }
                 $content = $moduleobject->set_content($linkarray, $cm);
                 $identifier = ($submissiontype === 'quiz_answer') ? sha1($content.$linkarray["itemid"]) : sha1($content);
+                $identifier = ($submissiontype === 'quiz_answer') ? sha1($linkarray['area']) : sha1($content);
             }
 
             // Group submissions where all students have to submit sets userid to 0.
@@ -2618,7 +2619,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
                 // Queue text content.
                 // adding slot to sha hash to create unique assignments for duplicate text based on it's id
-                $identifier = sha1($eventdata['other']['content'].$slot);
+                $identifier = sha1($eventdata['objectid']);
                 $result = $this->queue_submission_to_turnitin(
                         $cm, $author, $submitter, $identifier, 'quiz_answer',
                         $eventdata['objectid'], $eventdata['eventtype']);
@@ -3224,7 +3225,7 @@ function plagiarism_turnitin_send_queued_submissions() {
                 }
                 foreach ($attempt->get_slots() as $slot) {
                     $qa = $attempt->get_question_attempt($slot);
-                    if ($queueditem->identifier == sha1($qa->get_response_summary().$slot)) {
+                    if ($queueditem->identifier == sha1($queueditem->itemid)) {
                         $textcontent = $qa->get_response_summary();
                         break;
                     }

--- a/lib.php
+++ b/lib.php
@@ -753,7 +753,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     $submissiontype = 'quiz_answer';
                 }
                 $content = $moduleobject->set_content($linkarray, $cm);
-                $identifier = ($submissiontype === 'quiz_answer') ? sha1($content.$linkarray["itemid"]) : sha1($content);
                 $identifier = ($submissiontype === 'quiz_answer') ? sha1($linkarray['area']) : sha1($content);
             }
 


### PR DESCRIPTION
It seems a recent change to Moodle has moved storage of summaries for quiz question attempts to an asynchronous task. Therefore we can't use the hash of the summary as an identifier. I changed this to use basically a foreign key into the question_attempts table instead.