### PR TITLE
Replace print_error function

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -666,7 +666,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
             if ($cm->modname == 'forum') {
                 if (! $forum = $DB->get_record("forum", array("id" => $cm->instance))) {
-                    print_error('invalidforumid', 'forum');
+                    plagiarism_turnitin_print_error('invalidforumid', 'forum');
                 }
             }
         }
@@ -3448,7 +3448,7 @@ function plagiarism_turnitin_print_error($input, $module = 'plagiarism_turnitin'
         $message .= ' ('.basename($file).' | '.$line.')';
     }
 
-    print_error($input, 'plagiarism_turnitin', $link, $message);
+    throw new \moodle_exception($input, 'plagiarism_turnitin', $link, $message);
     exit();
 }
 


### PR DESCRIPTION
`print_error` is deprecated, we need to replace this by throwing a `moodle_exception`