### PR TITLE
Using is_enrolled for lti rubric launch check

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -161,17 +161,7 @@ switch ($action) {
         break;
 
     case "rubricview":
-        if ($cm->modname == "forum") {
-           $isstudent = has_capability('mod/forum:replypost', $context);
-        }
-        elseif ($cm->modname == "quiz") {
-          $isstudent = !has_capability('mod/quiz:viewoverrides', $context);
-        }
-        else {
-           $isstudent = has_capability('mod/'.$cm->modname.':submit', $context);
-        }
-
-        if ($isstudent) {
+        if (is_enrolled($context)) {
             $tiiassignment = $DB->get_record('plagiarism_turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_assignid'));
 
             $user = new turnitin_user($USER->id, "Learner");


### PR DESCRIPTION
Instead of checking arbitrary permissions, we should use the Moodle enrolment API to check whether a user should be able to view the rubric list