### PR TITLE
resubmitting a forum post fails

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -252,7 +252,7 @@ switch ($action) {
         }
 
         $forumdata = optional_param('forumdata', '', PARAM_ALPHANUMEXT);
-        $forumpost = optional_param('forumpost', '', PARAM_RAW);
+        $forumpost = optional_param('forumpost', '', PARAM_BASE64);
         $submissionid = required_param('submissionid', PARAM_INT);
 
         $tiisubmission = new turnitin_submission($submissionid,

--- a/ajax.php
+++ b/ajax.php
@@ -251,8 +251,8 @@ switch ($action) {
             throw new \moodle_exception('invalidsesskey', 'error');
         }
 
-        $forumdata = optional_param('forumdata', '', PARAM_ALPHAEXT);
-        $forumpost = optional_param('forumpost', '', PARAM_ALPHAEXT);
+        $forumdata = optional_param('forumdata', '', PARAM_ALPHANUMEXT);
+        $forumpost = optional_param('forumpost', '', PARAM_RAW);
         $submissionid = required_param('submissionid', PARAM_INT);
 
         $tiisubmission = new turnitin_submission($submissionid,

--- a/classes/modules/turnitin_forum.class.php
+++ b/classes/modules/turnitin_forum.class.php
@@ -154,6 +154,8 @@ class turnitin_forum {
      * @return string
      */
     public function get_discussionid($forumdata) {
+        global $CFG;
+        require_once($CFG->dirroot.'/mod/forum/lib.php');
 
         list($querystrid, $discussionid, $reply, $edit, $delete) = explode('_', $forumdata);
 

--- a/classes/turnitin_submission.class.php
+++ b/classes/turnitin_submission.class.php
@@ -122,6 +122,7 @@ class turnitin_submission {
 
             case 'forum_post':
                 $discussionid = $moduleobject->get_discussionid($this->data['forumdata']);
+                $content = base64_decode($this->data['forumpost']);
 
                 $forum = $DB->get_record("forum", ["id" => $this->cm->instance]);
 
@@ -131,16 +132,16 @@ class turnitin_submission {
                                                                 FROM {forum_posts} FP JOIN {forum_discussions} FD
                                                                 ON FP.discussion = FD.id
                                                                 WHERE FD.forum = ? AND FD.course = ?
-                                                                AND FP.userid = ? AND FP.message LIKE ? ',
+                                                                AND FP.userid = ? AND FP.message = ? ',
                                                                 [$forum->id, $forum->course,
-                                                                    $this->submissiondata->userid, $this->data['forumpost'], ]
+                                                                    $this->submissiondata->userid, $content, ]
                                                                 );
                     $discussionid = $discussion->id;
                 }
 
                 $submission = $DB->get_record_select('forum_posts',
-                                                " userid = ? AND message LIKE ? AND discussion = ? ",
-                                                [$this->submissiondata->userid, $this->data['forumpost'], $discussionid]);
+                                                " userid = ? AND message = ? AND discussion = ? ",
+                                                [$this->submissiondata->userid, $content, $discussionid]);
 
                 // Collate data and trigger new event for the cron to process.
                 $params = [
@@ -150,7 +151,7 @@ class turnitin_submission {
                     'userid' => $this->submissiondata->userid,
                     'other' => [
                         'pathnamehashes' => [],
-                        'content' => trim($this->data['forumpost']),
+                        'content' => trim($content),
                         'discussionid' => $discussionid,
                         'triggeredfrom' => 'turnitin_recreate_submission_event',
                     ],

--- a/classes/turnitin_submission.class.php
+++ b/classes/turnitin_submission.class.php
@@ -149,7 +149,7 @@ class turnitin_submission {
                     'objectid' => $submission->id,
                     'userid' => $this->submissiondata->userid,
                     'other' => [
-                        'pathnamehashes' => '',
+                        'pathnamehashes' => [],
                         'content' => trim($this->data['forumpost']),
                         'discussionid' => $discussionid,
                         'triggeredfrom' => 'turnitin_recreate_submission_event',

--- a/lib.php
+++ b/lib.php
@@ -1247,7 +1247,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
                             // Show hidden data for potential forum post resubmissions.
                             if ($submissiontype == 'forum_post' && !empty($linkarray["content"])) {
-                                $output .= html_writer::tag('div', $linkarray["content"],
+                                $output .= html_writer::tag('div', chunk_split(base64_encode($linkarray["content"]), 64),
                                                             ['class' => 'hidden', 'id' => 'content_'.$plagiarismfile->id]);
                             }
 


### PR DESCRIPTION
Based on Moodle 4.5. TL;DR: This fixes the obvious faults preventing ideal-world resubmission from working, but matching HTML on the page to what's in the database is quite unlikely to work in reality.

I don't know how you easily reproduce the conditions of a Forum post submission fault in normal usage, but one possible way to fudge it if you've got successful submissions already is to insert `$plagiarismfile->statuscode = 'error';` beneath [this line](https://github.com/turnitin/moodle-plagiarism_turnitin/blob/9ed9c4ca81808e14bda530e133f567e94391096e/lib.php#L1011) to display the resubmit UI, and then observe in your browser the call made to `plagiarism/turnitin/ajax.php` when you click on resubmit elements.

Here's the reasoning behind the patch:

`forum_get_post_full()` is a function defined in _mod/forum/lib.php_[^1] which won't be available if `turnitin_forum::get_discussionid()` is called during an ajax call to _ajax.php_:

```
Default exception handler: Exception - Call to undefined function forum_get_post_full() Debug: 
Error code: generalexceptionmessage
* line 87 of /plagiarism/turnitin/classes/modules/turnitin_forum.class.php: Error thrown
* line 106 of /plagiarism/turnitin/classes/turnitin_submission.class.php: call to turnitin_forum->get_discussionid()
* line 257 of /plagiarism/turnitin/ajax.php: call to turnitin_submission->recreate_submission_event()
```

Once you fix that issue, you encounter this:

```
Default exception handler: Error reading from database Debug: ERROR:  invalid input syntax for type bigint: ""
CONTEXT:  unnamed portal parameter $1 = ''
SELECT p.*, d.forum, u.firstnamephonetic, u.lastnamephonetic, u.middlename, u.alternatename, u.firstname, u.lastname, u.email, u.picture, u.imagealt
FROM mdl_forum_posts p
JOIN mdl_forum_discussions d ON p.discussion = d.id
LEFT JOIN mdl_user u ON p.userid = u.id
WHERE p.id = $1
[array (
  0 => '',
)]
Error code: dmlreadexception
* line 497 of /lib/dml/moodle_database.php: dml_read_exception thrown
* line 293 of /lib/dml/moodle_read_slave_trait.php: call to moodle_database->query_end()
* line 358 of /lib/dml/pgsql_native_moodle_database.php: call to pgsql_native_moodle_database->read_slave_query_end()
* line 1044 of /lib/dml/pgsql_native_moodle_database.php: call to pgsql_native_moodle_database->query_end()
* line 1687 of /lib/dml/moodle_database.php: call to pgsql_native_moodle_database->get_records_sql()
* line 917 of /mod/forum/lib.php: call to moodle_database->get_record_sql()
* line 89 of /plagiarism/turnitin/classes/modules/turnitin_forum.class.php: call to forum_get_post_full()
* line 106 of /plagiarism/turnitin/classes/turnitin_submission.class.php: call to turnitin_forum->get_discussionid()
* line 257 of /plagiarism/turnitin/ajax.php: call to turnitin_submission->recreate_submission_event()
```

That happens because [in ajax.php](https://github.com/turnitin/moodle-plagiarism_turnitin/blob/9ed9c4ca81808e14bda530e133f567e94391096e/ajax.php#L254) the _PARAM_ALPHAEXT_ type cleans the `0_12345_0_0_0` value of _forumdata_ sent to be '' giving an empty value back from `turnitin_forum::get_discussionid()`. Using _PARAM_ALPHANUMEXT_ instead accepts the digits.

This is still not enough though, because:

```
Default exception handler: Coding error detected, it must be fixed by a programmer: The 'pathnamehashes' value must be set in other and must be an array. Debug:
Error code: codingerror
* line 74 of /lib/classes/event/assessable_uploaded.php: core\exception\coding_exception thrown
* line 92 of /mod/forum/classes/event/assessable_uploaded.php: call to core\event\assessable_uploaded->validate_data()
* line 281 of /lib/classes/event/base.php: call to mod_forum\event\assessable_uploaded->validate_data()
* line 140 of /plagiarism/turnitin/classes/turnitin_submission.class.php: call to core\event\base::create()
* line 257 of /plagiarism/turnitin/ajax.php: call to turnitin_submission->recreate_submission_event()
```

Lastly, you also have to also change [the _PARAM_ALPHAEXT_ type for the _forumpost_ value](https://github.com/turnitin/moodle-plagiarism_turnitin/blob/9ed9c4ca81808e14bda530e133f567e94391096e/ajax.php#L255) to _PARAM_RAW_ or else the HTML of the post body being fed back by the ajax call gets cleaned to '' and [no submission record is matched](https://github.com/turnitin/moodle-plagiarism_turnitin/blob/9ed9c4ca81808e14bda530e133f567e94391096e/classes/turnitin_submission.class.php#L141). However, all of this is likely for naught if the forum post has any kind of filtering happening, such as smiley conversion or media embedding, because the HTML on the page being fed back by the ajax will not resemble the content of the post found in the database, but I'll leave devising a more reliable solution to that to you folks.

Jonathon

[^1]: `git grep 'function forum_get_post_full' {MOODLE_{{401..405},500}_STABLE,main}:mod/forum/lib.php`




