### PR TITLE
Adding curl_getinfo to API logging

### DIFF
--- a/vendor/Integrations/phpsdk-package/src/LTI.php
+++ b/vendor/Integrations/phpsdk-package/src/LTI.php
@@ -903,6 +903,13 @@ class LTI extends OAuthSimple {
 
         $result = curl_exec($ch);
 
+        // logpath will only be set if api logging is enabled
+        if (isset($this->logpath)) {
+          $info = curl_getinfo($ch);
+          $logger = new Logger( $this->logpath );
+          if ( $logger ) $logger->logInfo( 'LTI request curl info:' . PHP_EOL . json_encode($info, JSON_PRETTY_PRINT) );
+        }
+
         if( $result === false) {
             $err = 'Curl error: ' . curl_error($ch);
             $response = $err;

--- a/vendor/Integrations/phpsdk-package/src/Response.php
+++ b/vendor/Integrations/phpsdk-package/src/Response.php
@@ -36,10 +36,20 @@ class Response {
         $this->domobject = new \DomDocument();
         $this->requestdomobject = new \DomDocument();
         $logger = new Logger( $soap->getLogPath() );
-        if ( $logger ) $logger->logInfo( $soap->getHttpHeaders() . PHP_EOL . $soap->__getLastRequest() );
+        if ( $logger ) $logger->logInfo( 'Outgoing Request' . PHP_EOL .
+          '------------------------------------------------------------' . PHP_EOL .
+          'Headers' . PHP_EOL . 
+          '------------------------------------------------------------' . PHP_EOL .
+          $soap->getHttpHeaders() . PHP_EOL .
+          '------------------------------------------------------------' . PHP_EOL .
+          'Body' . PHP_EOL . 
+          '------------------------------------------------------------' . PHP_EOL .
+          $soap->__getLastRequest() . PHP_EOL);
         if ( $soap->getDebug() ) $this->outputDebug( $soap->__getLastRequest(), 'Request Message', $soap->getHttpHeaders() );
         @$this->requestdomobject->loadXML( $soap->__getLastRequest() );
-        if ( $logger ) $logger->logInfo( $soap->__getLastResponse() );
+        if ( $logger ) $logger->logInfo( 'Incoming Response:' . PHP_EOL . 
+          '------------------------------------------------------------' . PHP_EOL .
+          $soap->__getLastResponse() );
         if ( $soap->getDebug() ) $this->outputDebug( $soap->__getLastResponse(), 'Response Message' );
         if ( ($load = @$this->domobject->loadXML( $soap->__getLastResponse() )) === false ) {
             throw new TurnitinSDKException( 'responsexmlerror', 'XML Response could not be parsed', $soap->getLogPath() );

--- a/vendor/Integrations/phpsdk-package/src/Soap.php
+++ b/vendor/Integrations/phpsdk-package/src/Soap.php
@@ -411,6 +411,13 @@ class Soap extends \SoapClient
 
         $result = curl_exec($curl_handler);
 
+        // logpath will only be set if api logging is enabled
+        if (isset($this->logpath)) {
+          $info = curl_getinfo($curl_handler);
+          $logger = new Logger( $this->logpath );
+          if ( $logger ) $logger->logInfo( 'SOAP request curl info:' . PHP_EOL . json_encode($info, JSON_PRETTY_PRINT) );
+        }
+
         $this->httpresponse = $result;
         $this->httprequest = $request;
 


### PR DESCRIPTION
This adds more verbose logging which might help us track down network issues with the API in the future.