### PR TITLE
Adding index on statuscode for files table

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="plagiarism/turnitin/db" VERSION="20250723" COMMENT="XMLDB file for Moodle plagiarism/turnitin plugin"
+<XMLDB PATH="plagiarism/turnitin/db" VERSION="20250724" COMMENT="XMLDB file for Moodle plagiarism/turnitin plugin"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -34,6 +34,7 @@
       </KEYS>
       <INDEXES>
         <INDEX NAME="externalid" UNIQUE="false" FIELDS="externalid"/>
+        <INDEX NAME="statuscode" UNIQUE="false" FIELDS="statuscode"/>
       </INDEXES>
     </TABLE>
     <TABLE NAME="plagiarism_turnitin_config" COMMENT="info about plugin config">


### PR DESCRIPTION
As reported in #595 the DB query here is inefficient:
https://github.com/turnitin/moodle-plagiarism_turnitin/blob/develop/lib.php#L3241
Adding an index on statuscode will make this faster.