### PR TITLE
Quiz attempt hash updates

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -832,7 +832,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 }
                 $content = $moduleobject->set_content($linkarray, $cm);
                 if ($submissiontype === 'quiz_answer') {
-                  $identifier = sha1($linkarray['area'].$linkarray['itemid']);
+
+                  if (class_exists('\mod_quiz\quiz_attempt')) {
+                      $quizattemptclass = '\mod_quiz\quiz_attempt';
+                  } else {
+                      $quizattemptclass = 'quiz_attempt';
+                  }
+                  $attempt = $quizattemptclass::create($linkarray["area"]);
+
+                  $identifier = sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.
+                                     ' slot'.$linkarray["itemid"].' attempt'.$attempt->get_attempt_number());
                   $oldidentifier = sha1($content.$linkarray["itemid"]);
                 }
                 else {
@@ -2832,8 +2841,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $eventdata['other']['content'] = $qa->get_response_summary();
 
                 // Queue text content.
-                // Adding slot to sha hash to create unique assignments for duplicate text based on it's id.
-                $identifier = sha1($eventdata['other']['content'].$slot);
+                // We don't have access to the text content in the event handler, so use userid, cmid, slot, and attempt number to create a unique hash
+                $identifier = sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.' slot'.$slot.' attempt'.$attempt->get_attempt_number());
                 $result = $this->queue_submission_to_turnitin(
                         $cm, $author, $submitter, $identifier, 'quiz_answer',
                         $eventdata['objectid'], $eventdata['eventtype']);
@@ -3469,6 +3478,8 @@ function plagiarism_turnitin_send_queued_submissions() {
                     $title = 'forumpost_'.$user->id."_".$cm->id."_".$cm->instance."_".$queueditem->itemid.'.txt';
                     $filename = $title;
                 } else {
+                    plagiarism_turnitin_activitylog('File content not found on submission: '.$queueditem->identifier, 'PP_NO_FILE');
+                    mtrace('File content not found on submission. Identifier: '.$queueditem->identifier);
                     $errorcode = 9;
                 }
 
@@ -3490,12 +3501,17 @@ function plagiarism_turnitin_send_queued_submissions() {
 
                 } catch (Exception $e) {
                     plagiarism_turnitin_activitylog(get_string('errorcode14', 'plagiarism_turnitin'), "PP_NO_ATTEMPT");
+                    mtrace('Attempt not found on submission. Identifier: '.$queueditem->identifier);
                     $errorcode = 14;
                     break;
                 }
+
+                // Attempt to find the matching slot for the queued item.
+                // For each slot, check whether the hash matches.
                 foreach ($attempt->get_slots() as $slot) {
                     $qa = $attempt->get_question_attempt($slot);
-                    if ($queueditem->identifier == sha1($queueditem->itemid.$slot)) {
+                    if ($queueditem->identifier == sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.
+                                                        ' slot'.$slot.' attempt'.$attempt->get_attempt_number())) {
                         $textcontent = $qa->get_response_summary();
                         break;
                     }
@@ -3506,6 +3522,8 @@ function plagiarism_turnitin_send_queued_submissions() {
                     $title = 'quizanswer_'.$user->id."_".$cm->id."_".$cm->instance."_".$queueditem->itemid.'.txt';
                     $filename = $title;
                 } else {
+                    plagiarism_turnitin_activitylog('File content not found on submission: '.$queueditem->identifier, 'PP_NO_FILE');
+                    mtrace('File content not found on submission. Identifier: '.$queueditem->identifier);
                     $errorcode = 9;
                 }
 

--- a/lib.php
+++ b/lib.php
@@ -973,9 +973,18 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
                 // Get turnitin file details.
                 if (is_null($plagiarismfile)) {
-                    $plagiarismfiles = $DB->get_records('plagiarism_turnitin_files', array('userid' => $linkarray["userid"],
-                            'cm' => $linkarray["cmid"], 'identifier' => $identifier),
-                            'lastmodified DESC', '*', 0, 1);
+                    $params = [
+                        'userid' => $linkarray["userid"],
+                        'cm' => $linkarray["cmid"],
+                        'identifier1' => $identifier,
+                        'identifier2' => $oldidentifier,
+                    ];
+                    $sql = 'SELECT * FROM {plagiarism_turnitin_files}
+                            WHERE userid = :userid
+                            AND cm = :cm
+                            AND (identifier = :identifier1 OR identifier = :identifier2)
+                            ORDER BY lastmodified DESC';
+                    $plagiarismfiles = $DB->get_records_sql($sql, $params, 0, 1);
                     $plagiarismfile = current($plagiarismfiles);
                 }
 


### PR DESCRIPTION
For online text quiz attempts the hash lookup is failing as it's being calculated differently in `event_handler` vs `get_links`.
Also, hash collisions are possible when users upload the same text to two or more different quiz questions.
This PR adds a new hashing method that fixes both of these problems. We now calculate the hash for an online text quiz question attempt by concatenating the question type, the user id, the cmid, the slot, and the attempt id to create a unique string which is then hashed.
Example of generating a hash using the new method: `sha1(quiz_attempt user21 cm33 slot4 attempt1)`
This PR also adds a bit of extra logging for cron errors and implements looking submissions up by the previously generated hash to maintain backward compatibility.