### PR TITLE
Using group userid for group text content

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3447,7 +3447,7 @@ function plagiarism_turnitin_send_queued_submissions() {
                             $userid = ($moduledata->teamsubmission) ? 0 : $queueditem->userid;
 
                             $moodlesubmission = $DB->get_record('assign_submission', ['assignment' => $cm->instance,
-                                            'userid' => $queueditem->userid, 'id' => $queueditem->itemid, ], 'id');
+                                            'userid' => $userid, 'id' => $queueditem->itemid, ], 'id');
                             $moodletextsubmission = $DB->get_record('assignsubmission_onlinetext',
                                             ['submission' => $moodlesubmission->id], 'onlinetext');
                             $textcontent = $moodletextsubmission->onlinetext;


### PR DESCRIPTION
Looks like a typo in a previous PR, the `$queueditem->userid` refers to the uploader of a group submission, whereas `$userid` is 0 if it's a group submission.