### PR TITLE
Fix similarity scores not showing for group submissions with online text

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -974,14 +974,12 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 // Get turnitin file details.
                 if (is_null($plagiarismfile)) {
                     $params = [
-                        'userid' => $linkarray["userid"],
                         'cm' => $linkarray["cmid"],
                         'identifier1' => $identifier,
                         'identifier2' => $oldidentifier,
                     ];
                     $sql = 'SELECT * FROM {plagiarism_turnitin_files}
-                            WHERE userid = :userid
-                            AND cm = :cm
+                            WHERE cm = :cm
                             AND (identifier = :identifier1 OR identifier = :identifier2)
                             ORDER BY lastmodified DESC';
                     $plagiarismfiles = $DB->get_records_sql($sql, $params, 0, 1);


### PR DESCRIPTION
Fixes an issue where similarity scores are not showing for group submissions with online text.
The userid that we get in the linkarray will be 0 for such submissions, because they are group submissions. This means that the DB lookup will fail as the userid in the plagiarism_turnitin_files table will be the ID of the submitting user.
Since we're already performing a lookup based on a hash we don't really need the userid in this query