### PR TITLE
Issue #901: Update event observer with internal flag to prevent API calls during transactions

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -56,6 +56,7 @@ $observers = [
     [
         'eventname' => '\mod_quiz\event\attempt_submitted',
         'callback' => 'plagiarism_turnitin_observer::quiz_submitted',
+        'internal' => false,
     ],
     [
         'eventname' => '\core\event\course_module_deleted',

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2025073101;
+$plugin->version = 2025100800;
 
 $plugin->release = "4.1+";
 $plugin->requires = 2018051700;


### PR DESCRIPTION
Fix for #901 

- Marks the quiz submission event observer as non-internal. This ensures that the observer is triggered after transaction is closed for external integrations.
- Updates the plugin version to the latest release.