### PR TITLE
Fix quiz_attempt methods in unit tests for Moodle 4.5

### DIFF
--- a/tests/modules/turnitin_quiz_test.php
+++ b/tests/modules/turnitin_quiz_test.php
@@ -82,8 +82,12 @@ final class turnitin_quiz_test extends \advanced_testcase {
         quiz_start_new_attempt($quizobj, $quba, $attempt, 1, $timenow);
         quiz_attempt_save_started($quizobj, $quba, $attempt);
         $attemptobj = $quizattemptclass::create($attempt->id);
-        $attemptobj->process_submit($timenow, false);
-        $attemptobj->process_grade_submission($timenow);
+        if (method_exists($attemptobj, 'process_submit') && method_exists($attemptobj, 'process_grade_submission')) {
+            $attemptobj->process_submit($timenow, false);
+            $attemptobj->process_grade_submission($timenow);
+        } else {
+            $attemptobj->process_finish($timenow, false);
+        }
 
         // Expect no marks or grade for the attempt yet.
         $attemptobj = $quizattemptclass::create($attempt->id);


### PR DESCRIPTION
This resolves https://github.com/turnitin/moodle-plagiarism_turnitin/issues/920 for Moodle 4.5 (and older). The issue was introduced in https://github.com/turnitin/moodle-plagiarism_turnitin/commit/ead25a7ba26860bdc637dc8ee11d3ed28fdc1995 where `$attemptobj->process_finish($timenow, false);` was replaced by `process_submit()` and `process_grade_submission()` which exist in Moodle 5.0+ only (see https://moodle.atlassian.net/browse/MDL-68806).