### PR TITLE
Only request online text similarity score if quiz question has inline text

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2858,7 +2858,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 }
                 $eventdata['other']['content'] = $qa->get_response_summary();
 
-                // Queue text content only if the file submission type is 
+                // Queue text content only if the file submission type indicates that the quiz question contains online text
                 if ($qa->get_question()->responseformat !== 'noinline') {
                     // We don't have access to the text content in the event handler, so use userid, cmid, slot, and attempt number to create a unique hash
                     $identifier = sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.' slot'.$slot.' attempt'.$attempt->get_attempt_number());

--- a/lib.php
+++ b/lib.php
@@ -2858,12 +2858,14 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 }
                 $eventdata['other']['content'] = $qa->get_response_summary();
 
-                // Queue text content.
-                // We don't have access to the text content in the event handler, so use userid, cmid, slot, and attempt number to create a unique hash
-                $identifier = sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.' slot'.$slot.' attempt'.$attempt->get_attempt_number());
-                $result = $this->queue_submission_to_turnitin(
+                // Queue text content only if the file submission type is 
+                if ($qa->get_question()->responseformat !== 'noinline') {
+                    // We don't have access to the text content in the event handler, so use userid, cmid, slot, and attempt number to create a unique hash
+                    $identifier = sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.' slot'.$slot.' attempt'.$attempt->get_attempt_number());
+                    $result = $this->queue_submission_to_turnitin(
                         $cm, $author, $submitter, $identifier, 'quiz_answer',
                         $eventdata['objectid'], $eventdata['eventtype']);
+								}
 
                 $files = $qa->get_last_qt_files('attachments', $context->id);
                 foreach ($files as $file) {


### PR DESCRIPTION
Fixes a bug where similarity scores will be generated for the online text portion of quiz question attempts even when `no online text` is selected