### PR TITLE
Fix for group submission content hash collision

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -835,7 +835,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 } else if ($cm->modname == 'quiz') {
                     $submissiontype = 'quiz_answer';
                 }
-                $content = $moduleobject->set_content($linkarray, $cm);
+                $content = empty($linkarray['content']) ? $moduleobject->set_content($linkarray, $cm) : $linkarray['content'];
                 if ($submissiontype === 'quiz_answer') {
 
                   if (class_exists('\mod_quiz\quiz_attempt')) {


### PR DESCRIPTION
Currently when we display DV links/similarity scores next to submissions in Moodle, for group submissions with online text the same TFS ID is showing for each one under a given assignment.
This is happening because the code inside of `turnitin_assign->set_content` is doing a db query to get the text content of the submission, but that query doesn't take into account the group id. It's doing something like (pseudocode) `select * from assignments where userid = 123`. However, group assignments always have a userid of 0.
Fortunately in the particular instance that's causing this issue, we already have the text content passed to us by Moodle as part of the linkarray, so we don't actually need to perform this db query in the first place.
We might not always have `$linkarray['content'`, so I've left the existing code path in there as a backup in case it's not set.