### PR TITLE
Improve event handlers performance

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -28,42 +28,52 @@ $observers = [
     [
         'eventname' => '\assignsubmission_file\event\assessable_uploaded',
         'callback'  => 'plagiarism_turnitin_observer::assignsubmission_file_uploaded',
+        'internal'  => false
     ],
     [
         'eventname' => '\assignsubmission_onlinetext\event\assessable_uploaded',
         'callback'  => 'plagiarism_turnitin_observer::assignsubmission_onlinetext_uploaded',
+        'internal'  => false
     ],
     [
         'eventname' => '\mod_workshop\event\assessable_uploaded',
         'callback'  => 'plagiarism_turnitin_observer::workshop_file_uploaded',
+        'internal'  => false
     ],
     [
         'eventname' => '\mod_forum\event\assessable_uploaded',
         'callback'  => 'plagiarism_turnitin_observer::forum_file_uploaded',
+        'internal'  => false
     ],
     [
         'eventname' => '\mod_assign\event\assessable_submitted',
         'callback'  => 'plagiarism_turnitin_observer::assignsubmission_submitted',
+        'internal'  => false
     ],
     [
         'eventname' => '\mod_assign\event\submission_removed',
         'callback'  => 'plagiarism_turnitin_observer::assignsubmission_removed',
+        'internal'  => false
     ],
     [
         'eventname' => '\mod_coursework\event\assessable_uploaded',
         'callback'  => 'plagiarism_turnitin_observer::coursework_submitted',
+        'internal'  => false
     ],
     [
         'eventname' => '\mod_quiz\event\attempt_submitted',
         'callback' => 'plagiarism_turnitin_observer::quiz_submitted',
+        'internal' => false
     ],
     [
         'eventname' => '\core\event\course_module_deleted',
         'callback'  => 'plagiarism_turnitin_observer::course_module_deleted',
+        'internal'  => true
     ],
     [
         'eventname' => '\core\event\course_reset_ended',
         'callback'  => 'plagiarism_plugin_turnitin::course_reset',
         'includefile' => 'plagiarism/turnitin/lib.php',
+        'internal'  => true
     ],
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only changes to event observer registration; behavior should remain the same unless Moodle core treats `internal` observers differently in this environment.
> 
> **Overview**
> Annotates all `plagiarism_turnitin` event observers in `db/events.php` with an explicit `internal` flag.
> 
> Most submission-related observers are marked `internal => false`, while course cleanup observers (`course_module_deleted`, `course_reset_ended`) are marked `internal => true` to distinguish internal lifecycle handlers from user-facing events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 340296b09e63e8a7007bc4e556ef35864d090072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->