### PR TITLE
Refactor update reports task

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2247,13 +2247,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Add submission ids to the request.
         foreach ($submissions as $tiisubmission) {
-            // Updates the db field 'duedate_report_refresh' if the due date has passed within the last twenty four hours.
-            $now = strtotime('now');
-            $dtdue = (!empty($moduledata[$tiisubmission->modname]->duedate)) ? $moduledata[$tiisubmission->modname]->duedate : 0;
-            if ($tiisubmission->duedate_report_refresh != 1 && $now >= $dtdue && $now < strtotime('+1 day', $dtdue)) {
-                $this->set_duedate_report_refresh($tiisubmission->id, 1);
-            }
-
             if (!isset($reportsexpected[$tiisubmission->cm])) {
 
                 $reportsexpected[$tiisubmission->cm] = 1;

--- a/lib.php
+++ b/lib.php
@@ -2172,17 +2172,31 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     }
 
     /**
-     * Updates the database field duedate_report_refresh for any given submission ID.
-     * @param int $id - the ID of the submission to update.
+     * Updates the database field duedate_report_refresh for any given submission ID or array of IDs.
+     *
+     * @param int|int[] $id - the ID or array of IDs of the submission(s) to update.
      * @param int $newvalue - the value to which the field should be set.
      */
     public function set_duedate_report_refresh($id, $newvalue) {
         global $DB;
 
-        $updatedata = new stdClass();
-        $updatedata->id = $id;
-        $updatedata->duedate_report_refresh = $newvalue;
-        $DB->update_record('plagiarism_turnitin_files', $updatedata);
+        if (is_int($id)) {
+            $id = [$id];
+        }
+
+        // Chunk per 1000, conservative cross-DB limit for query parameter cap.
+        foreach (array_chunk($id, 1000) as $ids) {
+            [$insql, $inparams] = $DB->get_in_or_equal($ids, SQL_PARAMS_NAMED);
+            $sql = "UPDATE {plagiarism_turnitin_files}
+                       SET duedate_report_refresh = :newvalue1
+                     WHERE duedate_report_refresh != :newvalue2
+                       AND id $insql";
+
+            $params = ['newvalue1' => $newvalue, 'newvalue2' => $newvalue];
+            $params = array_merge($params, $inparams);
+
+            $DB->execute($sql, $params);
+        }
     }
 
     /**
@@ -2358,9 +2372,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Sets the duedate_report_refresh flag for each processed submission to 2 to prevent them being processed again in the
         // next cron run.
-        foreach ($submissions as $tiisubmission) {
-            $this->set_duedate_report_refresh($tiisubmission->id, 2);
-        }
+        $submissionids = array_map(function($s) {
+            return $s->id;
+        }, $submissions);
+        $this->set_duedate_report_refresh($submissionids, 2);
 
         return true;
     }

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -41,6 +41,7 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 #[CoversFunction('plagiarism_turnitin\plagiarism_plugin_turnitin::check_group_submission')]
 #[CoversFunction('plagiarism_turnitin\plagiarism_plugin_turnitin::plagiarism_get_report_gen_speed_params')]
 #[CoversFunction('plagiarism_turnitin\plagiarism_plugin_turnitin::plagiarism_set_config')]
+#[CoversFunction('plagiarism_turnitin\plagiarism_plugin_turnitin::set_duedate_report_refresh')]
 final class lib_test extends \advanced_testcase {
 
     /**
@@ -251,5 +252,61 @@ final class lib_test extends \advanced_testcase {
         } else {
             $this->assertObjectNotHasAttribute("plagiarism_turnitin_test", $config);
         }
+    }
+
+    /**
+     * Test set_duedate_report_refresh for single and bulk updates.
+     */
+    public function test_set_duedate_report_refresh(): void {
+        global $DB;
+        $this->resetAfterTest();
+
+        // Create course, module, and users for plagiarism_turnitin_files records.
+        $course = $this->getDataGenerator()->create_course();
+        $assigngenerator = $this->getDataGenerator()->get_plugin_generator('mod_assign');
+        $assign = $assigngenerator->create_instance(['course' => $course->id]);
+        $cm = get_coursemodule_from_instance('assign', $assign->id);
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+
+        // Create dummy records in plagiarism_turnitin_files.
+        $record1 = (object)[
+            'cm' => $cm->id,
+            'userid' => $user1->id,
+            'identifier' => 'id1',
+            'statuscode' => 'queued',
+            'similarityscore' => null,
+            'attempt' => 0,
+            'transmatch' => 0,
+            'submissiontype' => 'file',
+            'duedate_report_refresh' => 0
+        ];
+        $record2 = (object)[
+            'cm' => $cm->id,
+            'userid' => $user2->id,
+            'identifier' => 'id2',
+            'statuscode' => 'queued',
+            'similarityscore' => null,
+            'attempt' => 0,
+            'transmatch' => 0,
+            'submissiontype' => 'file',
+            'duedate_report_refresh' => 0
+        ];
+        $id1 = $DB->insert_record('plagiarism_turnitin_files', $record1);
+        $id2 = $DB->insert_record('plagiarism_turnitin_files', $record2);
+
+        $plugin = new \plagiarism_plugin_turnitin();
+
+        // Test single update.
+        $plugin->set_duedate_report_refresh($id1, 2);
+        $updated1 = $DB->get_record('plagiarism_turnitin_files', ['id' => $id1]);
+        $this->assertEquals(2, $updated1->duedate_report_refresh);
+
+        // Test bulk update.
+        $plugin->set_duedate_report_refresh([$id1, $id2], 1);
+        $updated1 = $DB->get_record('plagiarism_turnitin_files', ['id' => $id1]);
+        $updated2 = $DB->get_record('plagiarism_turnitin_files', ['id' => $id2]);
+        $this->assertEquals(1, $updated1->duedate_report_refresh);
+        $this->assertEquals(1, $updated2->duedate_report_refresh);
     }
 }


### PR DESCRIPTION
Some of our client are seeing 100 calls per second on this schedules task. This refactor optimises the call and reduces the number off calls and writer to the databases. Also removed a redundant call.