### PR TITLE
Add check for null externalid

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2211,6 +2211,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
           WHERE statuscode = ?
           AND ( similarityscore IS NULL OR duedate_report_refresh = 1 )
           AND ( orcapable = ? OR orcapable IS NULL )
+          AND externalid IS NOT NULL
           ORDER BY externalid DESC',
           ['success', 1]
         );
@@ -2225,7 +2226,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // Cache module data
         $moduledata = [];
-        foreach ($submissions as $submission) {
+        foreach ($submissions as $tiisubmission) {
             if (!array_key_exists($tiisubmission->modname, $moduledata)) {
                 $moduledata[$tiisubmission->modname] = $DB->get_record($tiisubmission->modname, ['id' => $tiisubmission->instance]);
             }


### PR DESCRIPTION
When the cron job runs to update scores for submissions, we should have a turnitin ID for each submission. If we don't, that means something went wrong creating it in TFS. This PR adds a null check to the database query which gets the list of submissions to retrieve scores for. If any of them don't have an externalid, we shouldn't try to retrieve a score.

Also included in this PR is a fix for a typo. A for loop was written with the wrong variable name, leading to incorrect caching of module settings. This PR fixes this.