### PR TITLE
Fix for accepting EULA during Behat test run

### DIFF
--- a/tests/behat/behat_plagiarism_turnitin.php
+++ b/tests/behat/behat_plagiarism_turnitin.php
@@ -242,6 +242,7 @@ class behat_plagiarism_turnitin extends behat_base {
             $this->execute('behat_general::i_click_on', [".pp_turnitin_eula_link", "css_element"]);
             $this->execute('behat_general::wait_until_exists', [".iframe-ltilaunch-eula", "css_element"]);
             $this->i_switch_to_iframe_with_locator(".iframe-ltilaunch-eula");
+            $this->i_switch_to_iframe_with_locator("#lti-frame");
             $this->execute('behat_general::i_click_on', [".agree-button", "css_element"]);
         } catch (Exception $e) {
             // EULA not found - so skip it.


### PR DESCRIPTION
At some point something has changed in the EULA iframe - it's now an iframe within an iframe, this causes this behat step to fail.

I think this won't have been spotted as this code will only run the first time you run the tests against a TII account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a conditional Behat step; no production plagiarism or LTI behavior is modified.
> 
> **Overview**
> Updates the Behat step **I accept the Turnitin EULA if necessary** so automation can reach the agree control after Turnitin’s EULA UI started loading inside a nested iframe.
> 
> After switching into `.iframe-ltilaunch-eula`, the step now switches into `#lti-frame` before clicking `.agree-button`, matching the new iframe-within-iframe structure that was causing first-run EULA acceptance tests to fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee3d9c91947e80ed3c5a7e010525f707018ae4a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->