### PR TITLE
Push post date by 6 months for marking workflow

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2033,7 +2033,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                                 ['assignment' => $cm->instance,
                                     'workflowstate' => 'released', ]);
 
-                            $dtpost = ($gradesreleased) ? strtotime('-5 minutes') : strtotime('+1 month');
+                            $dtpost = ($gradesreleased) ? strtotime('-5 minutes') : strtotime('+6 month');
                         }
                         break;
                     default:


### PR DESCRIPTION
For all other workflows where we're not sure when the post date should be, e.g. for anonymous marking, we will push the post date out by 6 months. For cases where we're using the Moodle marking workflow and the grades haven't been released yet, we currently push it by one month instead. This change makes it consistent by changing that to 6 months instead.