### PR TITLE
Allow submissions to be sent to TFS with invalid file types

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3421,10 +3421,12 @@ function plagiarism_turnitin_send_queued_submissions() {
                     }
 
                     // Prevent submissions queue breaking if file is wrong format
+                    $settings = $pluginturnitin->get_settings($cm->id);
+                    $acceptanyfiletype = (!empty($settings["plagiarism_allow_non_or_submissions"])) ? 1 : 0;
                     $filename = $file->get_filename();
                     $pathinfo = pathinfo($filename);
                     $extension = isset($pathinfo['extension']) ? $pathinfo['extension'] : '';
-                    if (!in_array('.'.$extension, $turnitinacceptedfiles)) {
+                    if (!$acceptanyfiletype || !in_array('.'.$extension, $turnitinacceptedfiles)) {
                         $errorstring = 'File with ID '.$queueditem->id.' cannot be sent to turnitin: File format is not supported. The filename is '
                           .$file->get_filename(). ' and the extension is '.$extension;
                         plagiarism_turnitin_activitylog($errorstring, 'PP_FILE_WRONG_FORMAT');


### PR DESCRIPTION
Fixes an issue observed where if "Allow any file type" is set, an error will still be shown when attempting to submit an unsupported file type.