### PR TITLE
Don't check eula in TFS if it's been accepted locally

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2544,7 +2544,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // If the EULA hasn't been accepted, don't save submission and don't submit to Tii.
         $tiiuser = $DB->get_record("plagiarism_turnitin_users", ["userid" => $author], "user_agreement_accepted");
-        if (!empty($tiiuser->user_agreement_accepted)) {
+        if (empty($tiiuser->user_agreement_accepted)) {
             $coursedata = $this->get_course_data($cm->id, $cm->course);
             $user = new turnitin_user($author, "Learner");
             $user->join_user_to_class($coursedata->turnitin_cid);

--- a/lib.php
+++ b/lib.php
@@ -2543,12 +2543,15 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $tiisubmissionid = null;
 
         // If the EULA hasn't been accepted, don't save submission and don't submit to Tii.
-        $coursedata = $this->get_course_data($cm->id, $cm->course);
-        $user = new turnitin_user($author, "Learner");
-        $user->join_user_to_class($coursedata->turnitin_cid);
-        $eulaaccepted = ($user->useragreementaccepted == 0) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
-        if ($eulaaccepted != 1) {
-            return true;
+        $tiiuser = $DB->get_record("plagiarism_turnitin_users", ["userid" => $author], "user_agreement_accepted");
+        if (!empty($tiiuser->user_agreement_accepted)) {
+            $coursedata = $this->get_course_data($cm->id, $cm->course);
+            $user = new turnitin_user($author, "Learner");
+            $user->join_user_to_class($coursedata->turnitin_cid);
+            $eulaaccepted = ($user->useragreementaccepted == 0) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
+            if ($eulaaccepted != 1) {
+                return true;
+            }
         }
 
         // If the submission is already in the queue in an error state, remove it


### PR DESCRIPTION
When queueing a submission, currently 2 synchronous calls to TFS happen to check the current acceptance state of the eula. However, we already store this value locally, and if we have it stored, there's no need to check TFS. This prevents unnecessary session locks if the api calls take a long time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow optimization in submission queueing; remote EULA verification still runs when local acceptance is unset, so behavior should match prior logic for unknown states.
> 
> **Overview**
> **`queue_submission_to_turnitin`** now reads **`user_agreement_accepted`** from **`plagiarism_turnitin_users`** before any Turnitin (TFS) work. When that field is already set (user accepted locally), the EULA block is skipped entirely.
> 
> If the local value is missing, behavior is unchanged: course data is loaded, the learner is joined to the class, and acceptance is resolved via **`turnitin_user`** / **`get_accepted_user_agreement`** (remote). Unaccepted users still return early without queuing.
> 
> This avoids two synchronous TFS calls on every queue when acceptance is already stored, reducing session lock risk during slow API responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03065c4ac34ac6ece8f7050a26757fb2079eed2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->