### PR TITLE
Add check for declined eula

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2544,7 +2544,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         // If the EULA hasn't been accepted, don't save submission and don't submit to Tii.
         $tiiuser = $DB->get_record("plagiarism_turnitin_users", ["userid" => $author], "user_agreement_accepted");
-        if (empty($tiiuser->user_agreement_accepted)) {
+        // -1 indicates the user declined the eula
+        if (empty($tiiuser->user_agreement_accepted) || $tiiuser->user_agreement_accepted == '-1') {
             $coursedata = $this->get_course_data($cm->id, $cm->course);
             $user = new turnitin_user($author, "Learner");
             $user->join_user_to_class($coursedata->turnitin_cid);


### PR DESCRIPTION
Found a bug in the previous PR - when we check the database to see if the user already accepted the eula, we're just checking if the database has a value other than zero. It's actually possible for the user to decline the eula, in which case we store -1 as the value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in submission queue EULA gating; aligns behavior with documented `-1` decline storage and reduces incorrect queuing for declined users.
> 
> **Overview**
> Fixes a bug in **`queue_submission_to_turnitin`** where a stored **`user_agreement_accepted`** value of **`-1`** (declined EULA, set via `ajax.php`) was treated as “already handled” because PHP’s **`empty()`** is false for `-1`.
> 
> The condition now also enters the EULA validation path when the value is **`-1`**, so declined users are re-checked (Turnitin / local state) and submissions are still blocked unless acceptance is **`1`**, matching behavior for unset or zero values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f09934b84bae7eda46efd18cd80ac4afb072276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->