### PR TITLE
Squashing bugs

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2529,7 +2529,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         // If the EULA hasn't been accepted, don't save submission and don't submit to Tii.
         $tiiuser = $DB->get_record("plagiarism_turnitin_users", ["userid" => $author], "user_agreement_accepted");
         // -1 indicates the user declined the eula
-        if (empty($tiiuser->user_agreement_accepted) || $tiiuser->user_agreement_accepted == '-1') {
+        if (isset($tiiuser) && empty($tiiuser->user_agreement_accepted) || $tiiuser->user_agreement_accepted == '-1') {
             $coursedata = $this->get_course_data($cm->id, $cm->course);
             $user = new turnitin_user($author, "Learner");
             $user->join_user_to_class($coursedata->turnitin_cid);

--- a/lib.php
+++ b/lib.php
@@ -2529,7 +2529,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         // If the EULA hasn't been accepted, don't save submission and don't submit to Tii.
         $tiiuser = $DB->get_record("plagiarism_turnitin_users", ["userid" => $author], "user_agreement_accepted");
         // -1 indicates the user declined the eula
-        if (isset($tiiuser) && empty($tiiuser->user_agreement_accepted) || $tiiuser->user_agreement_accepted == '-1') {
+        if (!isset($tiiuser) || empty($tiiuser->user_agreement_accepted) || $tiiuser->user_agreement_accepted == '-1') {
             $coursedata = $this->get_course_data($cm->id, $cm->course);
             $user = new turnitin_user($author, "Learner");
             $user->join_user_to_class($coursedata->turnitin_cid);

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 $plugin->version = 2025103101;
 
-$plugin->release = "4.1+";
+$plugin->release = "4.5+";
 $plugin->requires = 2018051700;
 $plugin->component = 'plagiarism_turnitin';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Address 2 small cursor bug finds before merge to QA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive condition on the submission queue path plus metadata in version.php; no auth or data-model changes.
> 
> **Overview**
> Fixes two small pre-QA issues in the Turnitin plagiarism plugin.
> 
> In `queue_submission_to_turnitin`, the EULA gate now treats a **missing** `plagiarism_turnitin_users` row as “not accepted” (`!isset($tiiuser)` before reading `user_agreement_accepted`). That avoids accessing a property on `false` when `get_record` returns nothing, and still runs the existing fallback that joins the learner and checks acceptance via `turnitin_user`.
> 
> `version.php` updates the advertised **`$plugin->release`** from `4.1+` to **`4.5+`** (version number unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b43ca8f4df38977bd00f3197ae4af118a06c420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->