### PR TITLE
Add grade sync cron task

### DIFF
--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -87,7 +87,7 @@ class sync_grades extends \core\task\scheduled_task {
                 $modinfo = get_fast_modinfo($course_id);
                 $cm = $modinfo->get_cm($assignment->cm);
                 $status = $pluginturnitin->update_grades_from_tii($cm);
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 mtrace('Failed to update grade from tii: ' . $e->getMessage());
                 continue;
             }

--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -51,8 +51,10 @@ class sync_grades extends \core\task\scheduled_task {
         global $DB;
 
         $one_week_in_seconds = 7 * 24 * 60 * 60;
+        $one_hour_in_seconds = 60 * 60;
         $current_time = time();
         $grade_sync_cutoff = $current_time - $one_week_in_seconds;
+        $resync_time = $current_time - $one_hour_in_seconds;
         mtrace('grade sync cutoff: ' . userdate($grade_sync_cutoff));
 
         $pluginturnitin = new \plagiarism_plugin_turnitin();
@@ -73,7 +75,7 @@ class sync_grades extends \core\task\scheduled_task {
         $grade_sync_assingments = $DB->get_records_sql($sql, $params);
 
         foreach ($grade_sync_assingments as $assignment) {
-            if ($assignment->duedate > $grade_sync_cutoff && $assignment->value < $current_time) {
+            if ($assignment->duedate > $grade_sync_cutoff && $assignment->value < $resync_time) {
                 mtrace('Attempting grade sync for cmid: ' . $assignment->cm . '...');
                 $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
                 $modinfo = get_fast_modinfo($course_id);

--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -55,11 +55,8 @@ class sync_grades extends \core\task\scheduled_task {
         }
 
         $one_week_in_seconds = 7 * 24 * 60 * 60;
-        $one_hour_in_seconds = 60 * 60;
         $current_time = time();
         $grade_sync_cutoff = $current_time - $one_week_in_seconds;
-        $resync_time = $current_time - $one_hour_in_seconds;
-        mtrace('grade sync cutoff: ' . userdate($grade_sync_cutoff));
 
         // Get list of all PP enabled activity modules that might need grade sync
         $sql = "SELECT ptc.id, ptc.cm, ptc.name, ptc.value, ptc.config_hash, m.name AS modtype,
@@ -73,27 +70,37 @@ class sync_grades extends \core\task\scheduled_task {
             LEFT JOIN {workshop} w ON (m.name = 'workshop' AND w.id = cm.instance)
                 WHERE ptc.name = :configname
                   AND m.name IN ('assign', 'quiz', 'forum', 'workshop')";
-        $params = ['configname' => 'grades_last_synced'];
-        $grade_sync_assingments = $DB->get_records_sql($sql, $params);
+        $params = ['configname' => 'turnitin_assignid'];
+        $grade_sync_assignments = $DB->get_records_sql($sql, $params);
 
-        foreach ($grade_sync_assingments as $assignment) {
-            if ($assignment->duedate > $grade_sync_cutoff && $assignment->value < $resync_time) {
-                mtrace('Attempting grade sync for cmid: ' . $assignment->cm . '...');
-                $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
-                $modinfo = get_fast_modinfo($course_id);
-                $cm = $modinfo->get_cm($assignment->cm);
-                $status = $pluginturnitin->update_grades_from_tii($cm);
-                if ($status) {
-                    $to_write = new \stdClass();
-                    $to_write->id = $assignment->id;
-                    $to_write->cm = $assignment->cm;
-                    $to_write->value = $current_time;
-                    $to_write->config_hash = $assignment->config_hash;
-                    $DB->update_record('plagiarism_turnitin_config', $to_write);
-                    mtrace('Successfully synced grades from Turnitin');
-                } else {
-                    mtrace('No new grades found in Turnitin');
-                }
+        foreach ($grade_sync_assignments as $assignment) {
+            if ($assignment->duedate != 0 && $assignment->duedate < $grade_sync_cutoff) {
+                continue;
+            }
+
+            $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
+            $modinfo = get_fast_modinfo($course_id);
+            $cm = $modinfo->get_cm($assignment->cm);
+            $status = $pluginturnitin->update_grades_from_tii($cm);
+            if ($status) {
+                mtrace('Successfully synced grades for cmid ' . $cm->id);
+            } else {
+               mtrace('No new grades found for cmid ' . $cm->id);
+            }
+
+            // Update the last synced time
+            $to_write = new \stdClass();
+            $to_write->cm = $assignment->cm;
+            $to_write->name = 'grades_last_synced';
+            $to_write->value = $current_time;
+            $to_write->config_hash = $assignment->cm . '_grades_last_synced';
+
+            $record = $DB->get_record('plagiarism_turnitin_config', [ 'name' => 'grades_last_synced', 'cm' => $assignment->cm ]);
+            if ($record) {
+                $to_write->id = $record->id;
+                $DB->update_record('plagiarism_turnitin_config', $to_write);
+            } else {
+                $DB->insert_record('plagiarism_turnitin_config', $to_write);
             }
         }
     }

--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -73,7 +73,7 @@ class sync_grades extends \core\task\scheduled_task {
         $grade_sync_assingments = $DB->get_records_sql($sql, $params);
 
         foreach ($grade_sync_assingments as $assignment) {
-            if ($assignment->duedate < $grade_sync_cutoff && $assignment->value < $current_time) {
+            if ($assignment->duedate > $grade_sync_cutoff && $assignment->value < $current_time) {
                 mtrace('Attempting grade sync for cmid: ' . $assignment->cm . '...');
                 $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
                 $modinfo = get_fast_modinfo($course_id);
@@ -83,7 +83,7 @@ class sync_grades extends \core\task\scheduled_task {
                     $to_write = new stdClass();
                     $to_write->id = $assignment->id;
                     $to_write->cm = $assignment->cm;
-                    $to_write->value = $assignment->value;
+                    $to_write->value = $current_time;
                     $to_write->config_hash = $assignment->config_hash;
                     $DB->update_record('plagiarism_turnitin_config', $to_write);
                     mtrace('Successfully synced grades from Turnitin');

--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -1,0 +1,87 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Send queued submissions to Turnitin.
+ *
+ * @package    plagiarism_turnitin
+ * @copyright  Turnitin
+ * @author     Jack Milgate http://www.turnitin.com
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace plagiarism_turnitin\task;
+
+require_once($CFG->dirroot.'/plagiarism/turnitin/lib.php');
+
+/**
+ * Send queued submissions to Turnitin.
+ */
+class sync_grades extends \core\task\scheduled_task {
+
+    /**
+     * Get the name of the task.
+     *
+     * @return \lang_string|string
+     * @throws \coding_exception
+     */
+    public function get_name() {
+        return get_string('syncgrades', 'plagiarism_turnitin');
+    }
+
+    /**
+     * Execute the task.
+     *
+     * @return void
+     */
+    public function execute() {
+        global $DB;
+
+        $one_week_in_seconds = 7 * 24 * 60 * 60;
+        $current_time = time();
+        $grade_sync_cutoff = $current_time - $one_week_in_seconds;
+        mtrace('grade sync cutoff: ' . userdate($grade_sync_cutoff));
+
+        $pluginturnitin = new \plagiarism_plugin_turnitin();
+
+        // Get list of all PP enabled assignments that might need grade sync
+        $grade_sync_assingments = $DB->get_records('plagiarism_turnitin_config', ['name' => 'grades_last_synced']);
+        foreach ($grade_sync_assingments as $assignment) {
+            $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
+            $modinfo = get_fast_modinfo($course_id);
+            $cm = $modinfo->get_cm($assignment->cm);
+            $course = $DB->get_record('course', ['id' => $course_id], '*', MUST_EXIST);
+            $dates = \core\activity_dates::get_dates_for_module($cm, 0);
+
+            foreach ($dates as $date) {
+                if ($date['dataid'] === 'duedate') {
+                    $due_date = $date['timestamp'];
+                    if ($due_date < $grade_sync_cutoff && $assignment->value < $current_time) {
+                        mtrace('Attempting grade sync for cmid: ' . $assignment->cm . '...');
+                        $status = $pluginturnitin->update_grades_from_tii($cm);
+                        if ($status) {
+                            $assignment->value = $current_time;
+                            $DB->update_record('plagiarism_turnitin_config', $assignment);
+                            mtrace('Successfully synced grades from Turnitin');
+                        } else {
+                            mtrace('No new grades found in Turnitin');
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -53,6 +53,10 @@ class sync_grades extends \core\task\scheduled_task {
         if (!$pluginturnitin->is_plugin_configured()) {
             return;
         }
+        if (!$pluginturnitin->test_turnitin_connection()) {
+            mtrace(get_string('ppeventsfailedconnection', 'plagiarism_turnitin'));
+            return;
+        }
 
         $one_week_in_seconds = 7 * 24 * 60 * 60;
         $current_time = time();
@@ -74,14 +78,20 @@ class sync_grades extends \core\task\scheduled_task {
         $grade_sync_assignments = $DB->get_records_sql($sql, $params);
 
         foreach ($grade_sync_assignments as $assignment) {
-            if (!empty($assignment->duedate) && $assignment->duedate < $grade_sync_cutoff) {
+            if ($assignment->duedate < $grade_sync_cutoff) {
                 continue;
             }
 
-            $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
-            $modinfo = get_fast_modinfo($course_id);
-            $cm = $modinfo->get_cm($assignment->cm);
-            $status = $pluginturnitin->update_grades_from_tii($cm);
+            try {
+                $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
+                $modinfo = get_fast_modinfo($course_id);
+                $cm = $modinfo->get_cm($assignment->cm);
+                $status = $pluginturnitin->update_grades_from_tii($cm);
+            } catch (Exception $e) {
+                mtrace('Failed to update grade from tii: ' . $e->getMessage());
+                continue;
+            }
+
             if ($status) {
                 mtrace('Successfully synced grades for cmid ' . $cm->id);
             } else {

--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -57,29 +57,38 @@ class sync_grades extends \core\task\scheduled_task {
 
         $pluginturnitin = new \plagiarism_plugin_turnitin();
 
-        // Get list of all PP enabled assignments that might need grade sync
-        $grade_sync_assingments = $DB->get_records('plagiarism_turnitin_config', ['name' => 'grades_last_synced']);
-        foreach ($grade_sync_assingments as $assignment) {
-            $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
-            $modinfo = get_fast_modinfo($course_id);
-            $cm = $modinfo->get_cm($assignment->cm);
-            $course = $DB->get_record('course', ['id' => $course_id], '*', MUST_EXIST);
-            $dates = \core\activity_dates::get_dates_for_module($cm, 0);
+        // Get list of all PP enabled activity modules that might need grade sync
+        $sql = "SELECT ptc.id, ptc.cm, ptc.name, ptc.value, ptc.config_hash, m.name AS modtype,
+                      COALESCE(a.duedate, q.timeclose, f.cutoffdate, w.submissionend) AS duedate
+                  FROM {plagiarism_turnitin_config} ptc
+                  JOIN {course_modules} cm ON cm.id = ptc.cm
+                  JOIN {modules} m ON m.id = cm.module
+            LEFT JOIN {assign} a ON (m.name = 'assign' AND a.id = cm.instance)
+            LEFT JOIN {quiz} q ON (m.name = 'quiz' AND q.id = cm.instance)
+            LEFT JOIN {forum} f ON (m.name = 'forum' AND f.id = cm.instance)
+            LEFT JOIN {workshop} w ON (m.name = 'workshop' AND w.id = cm.instance)
+                WHERE ptc.name = :configname
+                  AND m.name IN ('assign', 'quiz', 'forum', 'workshop')";
+        $params = ['configname' => 'grades_last_synced'];
+        $grade_sync_assingments = $DB->get_records_sql($sql, $params);
 
-            foreach ($dates as $date) {
-                if ($date['dataid'] === 'duedate') {
-                    $due_date = $date['timestamp'];
-                    if ($due_date < $grade_sync_cutoff && $assignment->value < $current_time) {
-                        mtrace('Attempting grade sync for cmid: ' . $assignment->cm . '...');
-                        $status = $pluginturnitin->update_grades_from_tii($cm);
-                        if ($status) {
-                            $assignment->value = $current_time;
-                            $DB->update_record('plagiarism_turnitin_config', $assignment);
-                            mtrace('Successfully synced grades from Turnitin');
-                        } else {
-                            mtrace('No new grades found in Turnitin');
-                        }
-                    }
+        foreach ($grade_sync_assingments as $assignment) {
+            if ($assignment->duedate < $grade_sync_cutoff && $assignment->value < $current_time) {
+                mtrace('Attempting grade sync for cmid: ' . $assignment->cm . '...');
+                $course_id = $DB->get_field('course_modules', 'course', ['id' => $assignment->cm], MUST_EXIST);
+                $modinfo = get_fast_modinfo($course_id);
+                $cm = $modinfo->get_cm($assignment->cm);
+                $status = $pluginturnitin->update_grades_from_tii($cm);
+                if ($status) {
+                    $to_write = new stdClass();
+                    $to_write->id = $assignment->id;
+                    $to_write->cm = $assignment->cm;
+                    $to_write->value = $assignment->value;
+                    $to_write->config_hash = $assignment->config_hash;
+                    $DB->update_record('plagiarism_turnitin_config', $to_write);
+                    mtrace('Successfully synced grades from Turnitin');
+                } else {
+                    mtrace('No new grades found in Turnitin');
                 }
             }
         }

--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -25,8 +25,6 @@
 
 namespace plagiarism_turnitin\task;
 
-require_once($CFG->dirroot.'/plagiarism/turnitin/lib.php');
-
 /**
  * Send queued submissions to Turnitin.
  */
@@ -48,7 +46,13 @@ class sync_grades extends \core\task\scheduled_task {
      * @return void
      */
     public function execute() {
-        global $DB;
+        global $CFG, $DB;
+        
+        require_once($CFG->dirroot.'/plagiarism/turnitin/lib.php');
+        $pluginturnitin = new \plagiarism_plugin_turnitin();
+        if (!$pluginturnitin->is_plugin_configured()) {
+            return;
+        }
 
         $one_week_in_seconds = 7 * 24 * 60 * 60;
         $one_hour_in_seconds = 60 * 60;
@@ -56,8 +60,6 @@ class sync_grades extends \core\task\scheduled_task {
         $grade_sync_cutoff = $current_time - $one_week_in_seconds;
         $resync_time = $current_time - $one_hour_in_seconds;
         mtrace('grade sync cutoff: ' . userdate($grade_sync_cutoff));
-
-        $pluginturnitin = new \plagiarism_plugin_turnitin();
 
         // Get list of all PP enabled activity modules that might need grade sync
         $sql = "SELECT ptc.id, ptc.cm, ptc.name, ptc.value, ptc.config_hash, m.name AS modtype,
@@ -82,7 +84,7 @@ class sync_grades extends \core\task\scheduled_task {
                 $cm = $modinfo->get_cm($assignment->cm);
                 $status = $pluginturnitin->update_grades_from_tii($cm);
                 if ($status) {
-                    $to_write = new stdClass();
+                    $to_write = new \stdClass();
                     $to_write->id = $assignment->id;
                     $to_write->cm = $assignment->cm;
                     $to_write->value = $current_time;

--- a/classes/task/sync_grades.php
+++ b/classes/task/sync_grades.php
@@ -74,7 +74,7 @@ class sync_grades extends \core\task\scheduled_task {
         $grade_sync_assignments = $DB->get_records_sql($sql, $params);
 
         foreach ($grade_sync_assignments as $assignment) {
-            if ($assignment->duedate != 0 && $assignment->duedate < $grade_sync_cutoff) {
+            if (!empty($assignment->duedate) && $assignment->duedate < $grade_sync_cutoff) {
                 continue;
             }
 

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -43,4 +43,13 @@ $tasks = [
         'dayofweek' => '*',
         'month' => '*',
     ],
+    [
+        'classname' => 'plagiarism_turnitin\task\sync_grades',
+        'blocking' => 0,
+        'minute' => '*/30',
+        'hour' => '*',
+        'day' => '*',
+        'dayofweek' => '*',
+        'month' => '*',
+    ],
 ];

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -254,6 +254,7 @@ $string['errorcode16'] = 'This file has not been submitted to Turnitin because t
 $string['queued'] = 'Queued';
 $string['updatereportscores'] = 'Update Report Scores for Turnitin Plagiarism Plugin';
 $string['sendqueuedsubmissions'] = 'Send Queued Files from the Turnitin Plagiarism Plugin';
+$string['syncgrades'] = 'Sync Grades for the Turnitin Plagiarism Plugin';
 
 $string['privacy:metadata:plagiarism_turnitin_files'] = 'Information that links a Moodle submission to a Turnitin submission.';
 $string['privacy:metadata:plagiarism_turnitin_files:userid'] = 'The ID of the user who has made a submission.';

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2025103102;
+$plugin->version = 2025103107;
 
 $plugin->release = "4.5+";
 $plugin->requires = 2018051700;


### PR DESCRIPTION
This PR adds a new scheduled task that runs every 30 mins to sync grades from Turnitin.
We'll attempt to automatically resync grades during the critical period up until 1 week after the due date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scheduled writes to the gradebook via Turnitin API reuse existing logic but run unattended across many course modules, so API or data issues could affect grades without a user triggering sync.
> 
> **Overview**
> Adds a **scheduled task** (`sync_grades`) that runs **every 30 minutes** to pull GradeMark grades from Turnitin into Moodle without an instructor manually refreshing the inbox.
> 
> For each activity that already has a Turnitin assignment ID (`turnitin_assignid`), the task resolves the module due date (assign, quiz, forum, or workshop), **skips** activities whose due date is more than **one week** in the past, then calls the existing **`update_grades_from_tii`** path. Failures are logged with `mtrace` and processing continues for other modules. After each attempt it upserts **`grades_last_synced`** on `plagiarism_turnitin_config`, matching the pattern used on instructor refresh in `ajax.php`.
> 
> Registration is in **`db/tasks.php`**, the admin task label comes from a new **`syncgrades`** lang string, and the plugin **version** is bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89ea4c051054fcd94bba3f8f654744a75b72a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->