### PR TITLE
Enable ad-hoc processing for submission queue

### DIFF
--- a/classes/forms/turnitin_setupform.class.php
+++ b/classes/forms/turnitin_setupform.class.php
@@ -46,6 +46,7 @@ class turnitin_setupform extends moodleform {
         global $DB, $CFG;
 
         $config = plagiarism_plugin_turnitin::plagiarism_turnitin_admin_config();
+        $ynoptions = [0 => get_string('no'), 1 => get_string('yes')];
 
         $mform = $this->_form;
 
@@ -67,6 +68,11 @@ class turnitin_setupform extends moodleform {
                 );
             }
         }
+
+        // Enable/disable the ad-hoc send submissions task
+        $mform->addElement('select', 'plagiarism_turnitin_enableadhocsubmissions', get_string('enableadhocsubmissions',
+            'plagiarism_turnitin'), $ynoptions);
+        $mform->setDefault('plagiarism_turnitin_enableadhocsubmissions', 0);
 
         $mform->addElement('header', 'plagiarism_turnitinconfig', get_string('tiiaccountconfig',
             'plagiarism_turnitin'));
@@ -102,7 +108,6 @@ class turnitin_setupform extends moodleform {
             'plagiarism_turnitin'));
         $mform->setExpanded('plagiarism_debugginglogs');
 
-        $ynoptions = [0 => get_string('no'), 1 => get_string('yes')];
         $diagnosticoptions = [
             0 => get_string('diagnosticoptions_0', 'plagiarism_turnitin'),
             1 => get_string('diagnosticoptions_1', 'plagiarism_turnitin'),
@@ -282,7 +287,7 @@ class turnitin_setupform extends moodleform {
 
         $properties = ["accountid", "secretkey", "apiurl", "enablediagnostic", "usegrademark", "enablepeermark",
             "useanon", "transmatch", "repositoryoption", "agreement", "enablepseudo", "pseudofirstname",
-            "pseudolastname", "lastnamegen", "pseudosalt", "pseudoemaildomain", ];
+            "pseudolastname", "lastnamegen", "pseudosalt", "pseudoemaildomain", "enableadhocsubmissions"];
 
         foreach ($properties as $property) {
             plagiarism_plugin_turnitin::plagiarism_set_config($data, "plagiarism_turnitin_".$property);

--- a/classes/task/adhoc_send_submission.php
+++ b/classes/task/adhoc_send_submission.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Ad-hoc task to send queued submissions to Turnitin.
+ *
+ * @package    plagiarism_turnitin
+ * @copyright  Turnitin
+ * @author     Jack Milgate http://www.turnitin.com
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace plagiarism_turnitin\task;
+
+/**
+ * Ad-hoc task which sends one individual submission to Turnitin.
+ * Can be run in parallel in order to speed up processing of submissions.
+ */
+class adhoc_send_submission extends \core\task\adhoc_task {
+
+    /**
+     * Get the name of the task.
+     *
+     * @return \lang_string|string
+     * @throws \coding_exception
+     */
+    public function get_name() {
+        return get_string('adhoc_sendqueuedsubmission', 'plagiarism_turnitin');
+    }
+
+    public static function instance($submission): self {
+        $task = new self();
+        $task->set_custom_data((object) [
+            'submission' => $submission,
+        ]);
+
+        $task->set_component('plagiarism_turnitin');
+
+        return $task;
+    }
+
+    /**
+     * Allow concurrent execution of this task.
+     *
+     * @return bool
+     */
+    public function is_no_concurrency_allowed() {
+        return false;
+    }
+
+    /**
+     * Execute the task.
+     *
+     * @return void
+     */
+    public function execute() {
+        global $CFG;
+
+        require_once($CFG->dirroot.'/plagiarism/turnitin/lib.php');
+        $plugin = new \plagiarism_plugin_turnitin();
+        if (!$plugin->is_plugin_configured()) {
+            return;
+        }
+
+        $data = $this->get_custom_data();
+
+        mtrace('Running ad-hoc task adhoc_sendqueuedsubmission for submission: ' . json_encode($data->submission));
+        \plagiarism_turnitin_send_single_submission($plugin, $data->submission);
+        mtrace('Ad-hoc task complete.');
+    }
+}

--- a/classes/task/send_submissions.php
+++ b/classes/task/send_submissions.php
@@ -46,13 +46,42 @@ class send_submissions extends \core\task\scheduled_task {
      * @return void
      */
     public function execute() {
-        global $CFG;
+        global $CFG, $DB;
 
         require_once($CFG->dirroot.'/plagiarism/turnitin/lib.php');
         $plugin = new \plagiarism_plugin_turnitin();
         if (!$plugin->is_plugin_configured()) {
             return;
         }
-        plagiarism_turnitin_send_queued_submissions();
+
+        $pluginconfig = get_config('plagiarism_turnitin');
+        if ($pluginconfig->plagiarism_turnitin_enableadhocsubmissions) {
+            // Don't attempt to call Turnitin if a connection to Turnitin could not be established.
+            if (!$plugin->test_turnitin_connection()) {
+                mtrace(get_string('ppeventsfailedconnection', 'plagiarism_turnitin'));
+                return;
+            }
+          
+            mtrace('Checking for queued submissions...');
+            $queueditems = $DB->get_records_select("plagiarism_turnitin_files",
+                "statuscode = 'queued' OR statuscode = 'pending'", null,
+                'lastmodified', '*', 0, PLAGIARISM_TURNITIN_CRON_SUBMISSIONS_LIMIT);
+            if (empty($queueditems)) {
+                mtrace('No queued items found.');
+                return;
+            }
+            mtrace('Found ' . count($queueditems) . ' queued submissions.');
+            mtrace('Queueing ad-hoc tasks...');
+            foreach ($queueditems as $item) {
+              $adhoctask = adhoc_send_submission::instance($item);
+              \core\task\manager::queue_adhoc_task($adhoctask);
+              mtrace('  Queued submission for upload: ' . json_encode($item));
+            }
+            mtrace('Done.');
+        } else {
+            mtrace('Sending submissions using scheduled task...');
+            plagiarism_turnitin_send_queued_submissions();
+            mtrace('Done.');
+        }
     }
 }

--- a/classes/task/send_submissions.php
+++ b/classes/task/send_submissions.php
@@ -65,7 +65,7 @@ class send_submissions extends \core\task\scheduled_task {
             mtrace('Checking for queued submissions...');
             $queueditems = $DB->get_records_select("plagiarism_turnitin_files",
                 "statuscode = 'queued' OR statuscode = 'pending'", null,
-                'lastmodified', '*', 0, PLAGIARISM_TURNITIN_CRON_SUBMISSIONS_LIMIT);
+                'lastmodified');
             if (empty($queueditems)) {
                 mtrace('No queued items found.');
                 return;

--- a/classes/task/send_submissions.php
+++ b/classes/task/send_submissions.php
@@ -74,16 +74,11 @@ class send_submissions extends \core\task\scheduled_task {
                 return;
             }
 
-            // Set the submissions status to in flight so subsequent cron runs don't try to queue them again.
-            // The status will be updated to either complete or error by the ad hoc task.
-            $DB->set_field_select("plagiarism_turnitin_files", "statuscode", "in_flight", 
-                "statuscode = 'queued' OR statuscode = 'pending'");
-
             mtrace('Found ' . count($queueditems) . ' queued submissions.');
             mtrace('Queueing ad-hoc tasks...');
             foreach ($queueditems as $item) {
               $adhoctask = adhoc_send_submission::instance($item);
-              \core\task\manager::queue_adhoc_task($adhoctask);
+              \core\task\manager::queue_adhoc_task($adhoctask, true);
               mtrace('  Queued submission for upload: ' . json_encode($item));
             }
             mtrace('Done.');

--- a/classes/task/send_submissions.php
+++ b/classes/task/send_submissions.php
@@ -63,13 +63,22 @@ class send_submissions extends \core\task\scheduled_task {
             }
           
             mtrace('Checking for queued submissions...');
+
+            // Grab all queued or pending submissions.
             $queueditems = $DB->get_records_select("plagiarism_turnitin_files",
                 "statuscode = 'queued' OR statuscode = 'pending'", null,
                 'lastmodified');
+
             if (empty($queueditems)) {
                 mtrace('No queued items found.');
                 return;
             }
+
+            // Set the submissions status to in flight so subsequent cron runs don't try to queue them again.
+            // The status will be updated to either complete or error by the ad hoc task.
+            $DB->set_field_select("plagiarism_turnitin_files", "statuscode", "in_flight", 
+                "statuscode = 'queued' OR statuscode = 'pending'");
+
             mtrace('Found ' . count($queueditems) . ' queued submissions.');
             mtrace('Queueing ad-hoc tasks...');
             foreach ($queueditems as $item) {

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -122,6 +122,7 @@ $string['id'] = 'Id';
 $string['student'] = 'Student';
 $string['course'] = 'Course';
 $string['module'] = 'Module';
+$string['enableadhocsubmissions'] = 'Enable ad-hoc task processing for the submission queue';
 
 $string['tiiaccountconfig'] = 'Turnitin Account Configuration';
 $string['turnitinaccountid'] = 'Turnitin Account ID';
@@ -255,6 +256,7 @@ $string['queued'] = 'Queued';
 $string['updatereportscores'] = 'Update Report Scores for Turnitin Plagiarism Plugin';
 $string['sendqueuedsubmissions'] = 'Send Queued Files from the Turnitin Plagiarism Plugin';
 $string['syncgrades'] = 'Sync Grades for the Turnitin Plagiarism Plugin';
+$string['adhoc_sendqueuedsubmission'] = 'Ad-hoc task: Send a queued submission from the Turnitin Plagiarism Plugin';
 
 $string['privacy:metadata:plagiarism_turnitin_files'] = 'Information that links a Moodle submission to a Turnitin submission.';
 $string['privacy:metadata:plagiarism_turnitin_files:userid'] = 'The ID of the user who has made a submission.';

--- a/lib.php
+++ b/lib.php
@@ -3247,9 +3247,8 @@ function plagiarism_turnitin_update_reports() {
  * Handle Scheduled Task to Send Queued Submissions to Turnitin.
  */
 function plagiarism_turnitin_send_queued_submissions() {
-    global $CFG, $DB, $turnitinacceptedfiles;
+    global $DB;
 
-    $config = plagiarism_plugin_turnitin::plagiarism_turnitin_admin_config();
     $pluginturnitin = new plagiarism_plugin_turnitin();
 
     // Don't attempt to call Turnitin if a connection to Turnitin could not be established.
@@ -3263,404 +3262,417 @@ function plagiarism_turnitin_send_queued_submissions() {
 
     // Submit each file individually to Turnitin.
     foreach ($queueditems as $queueditem) {
+        plagiarism_turnitin_send_single_submission($pluginturnitin, $queueditem);
+    }
+}
 
-        // Don't proceed if we can not find a cm.
-        $cm = get_coursemodule_from_id('', $queueditem->cm);
-        if (empty($cm)) {
-            $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 12);
+function plagiarism_turnitin_send_single_submission($pluginturnitin, $queueditem) {
+    global $CFG, $DB, $turnitinacceptedfiles;
 
-            // Output a message in the cron for failed submission to Turnitin.
-            $outputvars = new stdClass();
-            $outputvars->id = $queueditem->id;
-            $outputvars->cm = $queueditem->cm;
-            $outputvars->userid = $queueditem->userid;
+    $config = plagiarism_plugin_turnitin::plagiarism_turnitin_admin_config();
 
-            plagiarism_turnitin_activitylog(get_string('errorcode12', 'plagiarism_turnitin', $outputvars), "PP_NO_COURSE");
-            continue;
-        }
+    // Don't attempt to call Turnitin if a connection to Turnitin could not be established.
+    if (!$pluginturnitin->test_turnitin_connection()) {
+        mtrace(get_string('ppeventsfailedconnection', 'plagiarism_turnitin'));
+        return;
+    }
 
-        // Get various settings that we need.
-        $errorcode = 0;
-        $settings = $pluginturnitin->get_settings($cm->id);
+    // Don't proceed if we can not find a cm.
+    $cm = get_coursemodule_from_id('', $queueditem->cm);
+    if (empty($cm)) {
+        $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 12);
 
-        // Create module object.
-        if (empty($cm->modname)) {
-            $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 15);
+        // Output a message in the cron for failed submission to Turnitin.
+        $outputvars = new stdClass();
+        $outputvars->id = $queueditem->id;
+        $outputvars->cm = $queueditem->cm;
+        $outputvars->userid = $queueditem->userid;
 
-            // Output a message in the cron for failed submission to Turnitin.
-            $outputvars = new stdClass();
-            $outputvars->id = $queueditem->id;
-            $outputvars->cm = $queueditem->cm;
-            $outputvars->userid = $queueditem->userid;
+        plagiarism_turnitin_activitylog(get_string('errorcode12', 'plagiarism_turnitin', $outputvars), "PP_NO_COURSE");
+        return;
+    }
 
-            plagiarism_turnitin_activitylog(get_string('errorcode15', 'plagiarism_turnitin', $outputvars), "PP_NO_ACTIVITY_MODULE");
-            continue;
-        }
-        $moduleclass = "turnitin_".$cm->modname;
-        $moduleobject = new $moduleclass;
+    // Get various settings that we need.
+    $errorcode = 0;
+    $settings = $pluginturnitin->get_settings($cm->id);
 
-        // Get module data.
-        $moduledata = $DB->get_record($cm->modname, ['id' => $cm->instance]);
-        $moduledata->resubmission_allowed = false;
+    // Create module object.
+    if (empty($cm->modname)) {
+        $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 15);
 
-        if ($cm->modname == 'assign') {
-            // Group submissions require userid = 0 when checking assign_submission.
-            $userid = ($moduledata->teamsubmission) ? 0 : $queueditem->userid;
+        // Output a message in the cron for failed submission to Turnitin.
+        $outputvars = new stdClass();
+        $outputvars->id = $queueditem->id;
+        $outputvars->cm = $queueditem->cm;
+        $outputvars->userid = $queueditem->userid;
 
-            $moodlesubmission = $DB->get_record('assign_submission',
-                ['assignment' => $cm->instance,
-                    'userid' => $userid,
-                    'id' => $queueditem->itemid, ], 'status');
+        plagiarism_turnitin_activitylog(get_string('errorcode15', 'plagiarism_turnitin', $outputvars), "PP_NO_ACTIVITY_MODULE");
+        return;
+    }
+    
+    $moduleclass = "turnitin_".$cm->modname;
+    $moduleobject = new $moduleclass;
 
-            $moduledata->resubmission_allowed = $moduleobject->is_resubmission_allowed(
-                $cm->instance, $settings["plagiarism_report_gen"],
-                $queueditem->submissiontype,
-                $moduledata->maxattempts,
-                $moodlesubmission->status
-            );
-        }
+    // Get module data.
+    $moduledata = $DB->get_record($cm->modname, ['id' => $cm->instance]);
+    $moduledata->resubmission_allowed = false;
 
-        // Get course data.
-        $coursedata = $pluginturnitin->get_course_data($cm->id, $cm->course, 'cron');
-        // Save failed submission if class can not be created.
-        if (empty($coursedata->turnitin_cid)) {
-            $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 10);
-            continue;
-        }
-        // Update course data in Turnitin.
-        $turnitinassignment = new turnitin_assignment(0);
-        $turnitinassignment->edit_tii_course($coursedata);
+    if ($cm->modname == 'assign') {
+        // Group submissions require userid = 0 when checking assign_submission.
+        $userid = ($moduledata->teamsubmission) ? 0 : $queueditem->userid;
 
-        // Previously failed submissions may not have a value for submitter.
-        if (empty($queueditem->submitter)) {
-            $queueditem->submitter = $queueditem->userid;
-        }
+        $moodlesubmission = $DB->get_record('assign_submission',
+            ['assignment' => $cm->instance,
+             'userid'     => $userid,
+             'id'         => $queueditem->itemid, ], 'status');
 
-        // User Id should never be 0 but save as errored for old submissions where this may be the case.
-        if (empty($queueditem->userid)) {
-            $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 7);
-            continue;
-        }
+        $moduledata->resubmission_allowed = $moduleobject->is_resubmission_allowed(
+            $cm->instance, $settings["plagiarism_report_gen"],
+            $queueditem->submissiontype,
+            $moduledata->maxattempts,
+            $moodlesubmission->status
+        );
+    }
 
-        // Join User to course.
-        try {
-            $user = new turnitin_user($queueditem->userid, 'Learner', true, 'cron');
-            $user->edit_tii_user();
-            $user->join_user_to_class($coursedata->turnitin_cid);
-        } catch (Exception $e) {
-            $user = new turnitin_user($queueditem->userid, 'Learner', 'false', 'cron', 'false');
-            $errorcode = 7;
-        }
+    // Get course data.
+    $coursedata = $pluginturnitin->get_course_data($cm->id, $cm->course, 'cron');
+    // Save failed submission if class can not be created.
+    if (empty($coursedata->turnitin_cid)) {
+        $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 10);
+        return;
+    }
 
-        // Update assignment details in Turnitin.
-        $syncassignment = $pluginturnitin->sync_tii_assignment($cm, $coursedata->turnitin_cid, "cron", true);
+    // Update course data in Turnitin.
+    $turnitinassignment = new turnitin_assignment(0);
+    $turnitinassignment->edit_tii_course($coursedata);
 
-        // Any errorcode from assignment sync needs to be saved.
-        if (!empty($syncassignment['errorcode'])) {
-            $errorcode = $syncassignment['errorcode'];
-        }
+    // Previously failed submissions may not have a value for submitter.
+    if (empty($queueditem->submitter)) {
+        $queueditem->submitter = $queueditem->userid;
+    }
 
-        // Don't submit if a user has not accepted the eula.
-        if ($queueditem->userid == $queueditem->submitter && $user->useragreementaccepted != 1) {
-            $errorcode = 3;
-        }
+    // User Id should never be 0 but save as errored for old submissions where this may be the case.
+    if (empty($queueditem->userid)) {
+        $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 7);
+        return;
+    }
 
-        // There should never not be a submission type, handle if there isn't just in case.
-        if (!in_array($queueditem->submissiontype, ['file', 'text_content', 'forum_post', 'quiz_answer'])) {
-            $errorcode = 11;
-        }
+    // Join User to course.
+    try {
+        $user = new turnitin_user($queueditem->userid, 'Learner', true, 'cron');
+        $user->edit_tii_user();
+        $user->join_user_to_class($coursedata->turnitin_cid);
+    } catch (Exception $e) {
+        $user = new turnitin_user($queueditem->userid, 'Learner', 'false', 'cron', 'false');
+        $errorcode = 7;
+    }
 
-        if (!empty($errorcode)) {
-            // Save failed submission if user can not be joined to class or there was an error with the assignment.
-            $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, $errorcode);
-            continue;
-        }
+    // Update assignment details in Turnitin.
+    $syncassignment = $pluginturnitin->sync_tii_assignment($cm, $coursedata->turnitin_cid, "cron", true);
 
-        // Clean up old Turnitin submission files.
-        if ($queueditem->itemid != 0 && $queueditem->submissiontype == 'file' && $cm->modname != 'forum') {
-            $pluginturnitin->clean_old_turnitin_submissions($cm, $user->id, $queueditem->itemid, $queueditem->submissiontype,
-                                                    $queueditem->identifier);
-        }
+    // Any errorcode from assignment sync needs to be saved.
+    if (!empty($syncassignment['errorcode'])) {
+        $errorcode = $syncassignment['errorcode'];
+    }
 
-        // Get more Submission Details as required.
-        $apimethod = "createSubmission";
-        switch ($queueditem->submissiontype) {
-            case 'file':
-            case 'text_content':
+    // Don't submit if a user has not accepted the eula.
+    if ($queueditem->userid == $queueditem->submitter && $user->useragreementaccepted != 1) {
+        $errorcode = 3;
+    }
 
-                // Get file data or prepare text submission.
-                if ($queueditem->submissiontype == 'file') {
-                    $fs = get_file_storage();
-                    $file = $fs->get_file_by_hash($queueditem->identifier);
+    // There should never not be a submission type, handle if there isn't just in case.
+    if (!in_array($queueditem->submissiontype, ['file', 'text_content', 'forum_post', 'quiz_answer'])) {
+        $errorcode = 11;
+    }
 
-                    if (!$file) {
-                        plagiarism_turnitin_activitylog('File not found for submission: '.$queueditem->id, 'PP_NO_FILE');
-                        mtrace('File not found for submission. Identifier: '.$queueditem->id);
-                        $errorcode = 9;
-                        break;
-                    }
+    if (!empty($errorcode)) {
+        // Save failed submission if user can not be joined to class or there was an error with the assignment.
+        $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, $errorcode);
+        return;
+    }
 
-                    // Prevent submissions queue breaking if file is too large and a larger size limit has been set in Moodle
-                    if ($file->get_filesize() > PLAGIARISM_TURNITIN_MAX_FILE_UPLOAD_SIZE) {
-                        $errorstring = 'File with ID '.$queueditem->id.' cannot be sent to turnitin: File size is '.$file->get_filesize().
-                            ' bytes, and the max filesize that Turnitin can accept is '.PLAGIARISM_TURNITIN_MAX_FILE_UPLOAD_SIZE.' bytes.';
-                        plagiarism_turnitin_activitylog($errorstring, 'PP_FILE_TOO_LARGE');
-                        mtrace($errorstring);
-                        $errorcode = 2;
-                        break;
-                    }
+    // Clean up old Turnitin submission files.
+    if ($queueditem->itemid != 0 && $queueditem->submissiontype == 'file' && $cm->modname != 'forum') {
+        $pluginturnitin->clean_old_turnitin_submissions($cm, $user->id, $queueditem->itemid, $queueditem->submissiontype,
+                                                        $queueditem->identifier);
+    }
 
-                    // Prevent submissions queue breaking if file is wrong format
-                    $settings = $pluginturnitin->get_settings($cm->id);
-                    $acceptanyfiletype = (!empty($settings["plagiarism_allow_non_or_submissions"])) ? 1 : 0;
-                    $filename = $file->get_filename();
-                    $pathinfo = pathinfo($filename);
-                    $extension = isset($pathinfo['extension']) ? $pathinfo['extension'] : '';
-                    if (!$acceptanyfiletype && !in_array('.'.$extension, $turnitinacceptedfiles)) {
-                        $errorstring = 'File with ID '.$queueditem->id.' cannot be sent to turnitin: File format is not supported. The filename is '
-                          .$file->get_filename(). ' and the extension is '.$extension;
-                        plagiarism_turnitin_activitylog($errorstring, 'PP_FILE_WRONG_FORMAT');
-                        mtrace($errorstring);
-                        $errorcode = 16;
-                        break;
-                    }
+    // Get more Submission Details as required.
+    $apimethod = "createSubmission";
+    switch ($queueditem->submissiontype) {
+        case 'file':
+        case 'text_content':
+            // Get file data or prepare text submission.
+            if ($queueditem->submissiontype == 'file') {
+                $fs = get_file_storage();
+                $file = $fs->get_file_by_hash($queueditem->identifier);
 
-                    $title = $file->get_filename();
-                    $filename = $file->get_filename();
-
-                    try {
-                        $textcontent = $file->get_content();
-                    } catch (Exception $e) {
-                        plagiarism_turnitin_activitylog('File content not found on submission: '.$queueditem->identifier,
-                            'PP_NO_FILE');
-                        mtrace($e);
-                        mtrace('File content not found on submission. Identifier: '.$queueditem->identifier);
-                        $errorcode = 9;
-                        break;
-                    }
-                } else {
-                    // Get the actual text content for a submission.
-                    switch ($cm->modname) {
-                        case 'assign':
-                            $userid = ($moduledata->teamsubmission) ? 0 : $queueditem->userid;
-
-                            $moodlesubmission = $DB->get_record('assign_submission', ['assignment' => $cm->instance,
-                                            'userid' => $userid, 'id' => $queueditem->itemid, ], 'id');
-                            $moodletextsubmission = $DB->get_record('assignsubmission_onlinetext',
-                                            ['submission' => $moodlesubmission->id], 'onlinetext');
-                            $textcontent = $moodletextsubmission->onlinetext;
-                            break;
-
-                        case 'workshop':
-                            $moodlesubmission = $DB->get_record('workshop_submissions',
-                                                        ['id' => $queueditem->itemid], 'content');
-                            $textcontent = $moodlesubmission->content;
-                            break;
-                    }
-
-                    $title = 'onlinetext_'.$user->id."_".$cm->id."_".$cm->instance.'.txt';
-                    $filename = $title;
-                    $textcontent = html_to_text($textcontent);
-                }
-
-                // Use Replace submission method if resubmissions are allowed or create if we have no Turnitin Id.
-                if (!is_null($queueditem->externalid)) {
-                    $apimethod = ($moduledata->resubmission_allowed) ? "replaceSubmission" : "createSubmission";
-
-                    // Delete old text content submissions from Turnitin if not replacing.
-                    if ($settings["plagiarism_report_gen"] == 0 && $queueditem->submissiontype == 'text_content') {
-                        $pluginturnitin->delete_tii_submission($cm, $queueditem->externalid, $queueditem->userid);
-                    }
-                }
-
-                // Remove any old text submissions from Moodle DB if there are any as there is only one per submission.
-                if (!empty($queueditem->itemid) && $queueditem->submissiontype == "text_content") {
-                    $pluginturnitin->clean_old_turnitin_submissions($cm, $user->id, $queueditem->itemid,
-                                                                    $queueditem->submissiontype, $queueditem->identifier);
-                }
-
-                break;
-
-            case 'forum_post':
-                if (!is_null($queueditem->externalid)) {
-                    $apimethod = ($settings["plagiarism_report_gen"] == 0) ? "createSubmission" : "replaceSubmission";
-                }
-
-                $forumpost = $DB->get_record_select('forum_posts', " userid = ? AND id = ? ", [$user->id, $queueditem->itemid]);
-
-                if ($forumpost) {
-                    $textcontent = strip_tags($forumpost->message);
-                    $title = 'forumpost_'.$user->id."_".$cm->id."_".$cm->instance."_".$queueditem->itemid.'.txt';
-                    $filename = $title;
-                } else {
-                    plagiarism_turnitin_activitylog('File content not found on submission: '.$queueditem->identifier, 'PP_NO_FILE');
-                    mtrace('File content not found on submission. Identifier: '.$queueditem->identifier);
+                if (!$file) {
+                    plagiarism_turnitin_activitylog('File not found for submission: '.$queueditem->id, 'PP_NO_FILE');
+                    mtrace('File not found for submission. Identifier: '.$queueditem->id);
                     $errorcode = 9;
-                }
-
-                break;
-
-            case 'quiz_answer':
-                if (!is_null($queueditem->externalid)) {
-                    $apimethod = ($settings["plagiarism_report_gen"] == 0) ? "createSubmission" : "replaceSubmission";
-                }
-
-                require_once($CFG->dirroot . '/mod/quiz/locallib.php');
-                try {
-                    $attempt = \mod_quiz\quiz_attempt::create($queueditem->itemid);
-                } catch (Exception $e) {
-                    plagiarism_turnitin_activitylog(get_string('errorcode14', 'plagiarism_turnitin'), "PP_NO_ATTEMPT");
-                    mtrace('Attempt not found on submission. Identifier: '.$queueditem->identifier);
-                    $errorcode = 14;
                     break;
                 }
 
-                // Attempt to find the matching slot for the queued item.
-                // For each slot, check whether the hash matches.
-                foreach ($attempt->get_slots() as $slot) {
-                    $qa = $attempt->get_question_attempt($slot);
-                    if ($queueditem->identifier == sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.
-                                                        ' slot'.$slot.' attempt'.$attempt->get_attempt_number())) {
-                        $textcontent = $qa->get_response_summary();
-                        break;
-                    }
+                // Prevent submissions queue breaking if file is too large and a larger size limit has been set in Moodle
+                if ($file->get_filesize() > PLAGIARISM_TURNITIN_MAX_FILE_UPLOAD_SIZE) {
+                    $errorstring = 'File with ID '.$queueditem->id.' cannot be sent to turnitin: File size is '.$file->get_filesize().
+                        ' bytes, and the max filesize that Turnitin can accept is '.PLAGIARISM_TURNITIN_MAX_FILE_UPLOAD_SIZE.' bytes.';
+                    plagiarism_turnitin_activitylog($errorstring, 'PP_FILE_TOO_LARGE');
+                    mtrace($errorstring);
+                    $errorcode = 2;
+                    break;
                 }
 
-                if (!empty($textcontent)) {
-                    $textcontent = strip_tags($textcontent);
-                    $title = 'quizanswer_'.$user->id."_".$cm->id."_".$cm->instance."_".$queueditem->itemid.'.txt';
-                    $filename = $title;
-                } else {
+                // Prevent submissions queue breaking if file is wrong format
+                $settings = $pluginturnitin->get_settings($cm->id);
+                $acceptanyfiletype = (!empty($settings["plagiarism_allow_non_or_submissions"])) ? 1 : 0;
+                $filename = $file->get_filename();
+                $pathinfo = pathinfo($filename);
+                $extension = isset($pathinfo['extension']) ? $pathinfo['extension'] : '';
+                if (!$acceptanyfiletype && !in_array('.'.$extension, $turnitinacceptedfiles)) {
+                    $errorstring = 'File with ID '.$queueditem->id.' cannot be sent to turnitin: File format is not supported. The filename is '
+                      .$file->get_filename(). ' and the extension is '.$extension;
+                    plagiarism_turnitin_activitylog($errorstring, 'PP_FILE_WRONG_FORMAT');
+                    mtrace($errorstring);
+                    $errorcode = 16;
+                    break;
+                }
+
+                $title = $file->get_filename();
+                $filename = $file->get_filename();
+
+                try {
+                    $textcontent = $file->get_content();
+                } catch (Exception $e) {
                     plagiarism_turnitin_activitylog('File content not found on submission: '.$queueditem->identifier, 'PP_NO_FILE');
+                    mtrace($e);
                     mtrace('File content not found on submission. Identifier: '.$queueditem->identifier);
                     $errorcode = 9;
+                    break;
+                }
+            } else {
+                // Get the actual text content for a submission.
+                switch ($cm->modname) {
+                    case 'assign':
+                        $userid = ($moduledata->teamsubmission) ? 0 : $queueditem->userid;
+
+                        $moodlesubmission = $DB->get_record('assign_submission', ['assignment' => $cm->instance,
+                                        'userid' => $userid, 'id' => $queueditem->itemid, ], 'id');
+                        $moodletextsubmission = $DB->get_record('assignsubmission_onlinetext',
+                                        ['submission' => $moodlesubmission->id], 'onlinetext');
+                        $textcontent = $moodletextsubmission->onlinetext;
+                        break;
+
+                    case 'workshop':
+                        $moodlesubmission = $DB->get_record('workshop_submissions',
+                                                    ['id' => $queueditem->itemid], 'content');
+                        $textcontent = $moodlesubmission->content;
+                        break;
                 }
 
+                $title = 'onlinetext_'.$user->id."_".$cm->id."_".$cm->instance.'.txt';
+                $filename = $title;
+                $textcontent = html_to_text($textcontent);
+            }
+
+            // Use Replace submission method if resubmissions are allowed or create if we have no Turnitin Id.
+            if (!is_null($queueditem->externalid)) {
+                $apimethod = ($moduledata->resubmission_allowed) ? "replaceSubmission" : "createSubmission";
+
+                // Delete old text content submissions from Turnitin if not replacing.
+                if ($settings["plagiarism_report_gen"] == 0 && $queueditem->submissiontype == 'text_content') {
+                    $pluginturnitin->delete_tii_submission($cm, $queueditem->externalid, $queueditem->userid);
+                }
+            }
+
+            // Remove any old text submissions from Moodle DB if there are any as there is only one per submission.
+            if (!empty($queueditem->itemid) && $queueditem->submissiontype == "text_content") {
+                $pluginturnitin->clean_old_turnitin_submissions($cm, $user->id, $queueditem->itemid,
+                                                                $queueditem->submissiontype, $queueditem->identifier);
+            }
+
+            break;
+
+        case 'forum_post':
+            if (!is_null($queueditem->externalid)) {
+                $apimethod = ($settings["plagiarism_report_gen"] == 0) ? "createSubmission" : "replaceSubmission";
+            }
+
+            $forumpost = $DB->get_record_select('forum_posts', " userid = ? AND id = ? ", [$user->id, $queueditem->itemid]);
+
+            if ($forumpost) {
+                $textcontent = strip_tags($forumpost->message);
+                $title = 'forumpost_'.$user->id."_".$cm->id."_".$cm->instance."_".$queueditem->itemid.'.txt';
+                $filename = $title;
+            } else {
+                plagiarism_turnitin_activitylog('File content not found on submission: '.$queueditem->identifier, 'PP_NO_FILE');
+                mtrace('File content not found on submission. Identifier: '.$queueditem->identifier);
+                $errorcode = 9;
+            }
+
+            break;
+
+        case 'quiz_answer':
+            if (!is_null($queueditem->externalid)) {
+                $apimethod = ($settings["plagiarism_report_gen"] == 0) ? "createSubmission" : "replaceSubmission";
+            }
+
+            require_once($CFG->dirroot . '/mod/quiz/locallib.php');
+            try {
+                $attempt = \mod_quiz\quiz_attempt::create($queueditem->itemid);
+            } catch (Exception $e) {
+                plagiarism_turnitin_activitylog(get_string('errorcode14', 'plagiarism_turnitin'), "PP_NO_ATTEMPT");
+                mtrace('Attempt not found on submission. Identifier: '.$queueditem->identifier);
+                $errorcode = 14;
                 break;
-        }
-
-        // Save failed submission and don't process any further.
-        if ($errorcode != 0) {
-            $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, $errorcode);
-            continue;
-        }
-
-        // Read the stored file/content into a temp file for submitting.
-        $submissiontitle = explode('.', $title);
-
-        // Initialise file string array for naming the file.
-        $filestring = [$submissiontitle[0], $cm->id];
-
-        // Only include user's name and id if we're not using blind marking and student privacy.
-        if ( empty($moduledata->blindmarking) && empty($config->plagiarism_turnitin_enablepseudo) ) {
-            $userdetails = [
-                $user->id,
-                $user->firstname,
-                $user->lastname,
-            ];
-
-            $filestring = array_merge($userdetails, $filestring);
-        }
-
-        // Don't proceed if we can not create a tempfile.
-        try {
-            $tempfile = plagiarism_turnitin_tempfile($filestring, $filename);
-        } catch (Exception $e) {
-            $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 8);
-            continue;
-        }
-
-        $fh = fopen($tempfile, "w");
-        fwrite($fh, $textcontent);
-        fclose($fh);
-
-        // Create submission object.
-        $submission = new TiiSubmission();
-        $submission->setAssignmentId($syncassignment['tiiassignmentid']);
-        if ($apimethod == "replaceSubmission") {
-            $submission->setSubmissionId($queueditem->externalid);
-        }
-        $submission->setTitle($title);
-        $submission->setAuthorUserId($user->tiiuserid);
-
-        // Account for submission by teacher in assignment module.
-        $submission->setSubmitterUserId($user->tiiuserid);
-        $submission->setRole('Learner');
-
-        if ($queueditem->userid != $queueditem->submitter) {
-
-            $instructor = new turnitin_user($queueditem->submitter, 'Instructor');
-
-            // These should be true but in case of an edge case where a user has been deleted in Tii.
-            if ($instructor->edit_tii_user() && $instructor->join_user_to_class($coursedata->turnitin_cid)) {
-
-                $submission->setSubmitterUserId($instructor->tiiuserid);
-                $submission->setRole('Instructor');
-            }
-        }
-
-        $submission->setSubmissionDataPath($tempfile);
-
-        // Initialise Comms Object.
-        $turnitincomms = new turnitin_comms();
-        $turnitincall = $turnitincomms->initialise_api();
-
-        try {
-            $response = $turnitincall->$apimethod($submission);
-            $newsubmission = $response->getSubmission();
-            $tiisubmissionid = $newsubmission->getSubmissionId();
-
-            $pluginturnitin->save_submission($cm, $user->id, $queueditem->id, $queueditem->identifier, 'success', $tiisubmissionid,
-                                    $queueditem->submitter, $queueditem->itemid, $queueditem->submissiontype, $queueditem->attempt);
-
-            // Delete the tempfile.
-            if (!is_null($tempfile)) {
-                unlink($tempfile);
             }
 
-            plagiarism_turnitin_lock_anonymous_marking($cm->id);
+            // Attempt to find the matching slot for the queued item.
+            // For each slot, check whether the hash matches.
+            foreach ($attempt->get_slots() as $slot) {
+                $qa = $attempt->get_question_attempt($slot);
+                if ($queueditem->identifier == sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.
+                                                    ' slot'.$slot.' attempt'.$attempt->get_attempt_number())) {
+                    $textcontent = $qa->get_response_summary();
+                    break;
+                }
+            }
 
-            // Send a message to the user's Moodle inbox with the digital receipt.
-            $receipt = new pp_receipt_message();
-            $input = [
-                'firstname' => $user->firstname,
-                'lastname' => $user->lastname,
-                'submission_title' => $title,
-                'assignment_name' => $moduledata->name,
-                'course_fullname' => $coursedata->turnitin_ctl,
-                'submission_date' => date('d-M-Y h:iA'),
-                'submission_id' => $tiisubmissionid,
-            ];
+            if (!empty($textcontent)) {
+                $textcontent = strip_tags($textcontent);
+                $title = 'quizanswer_'.$user->id."_".$cm->id."_".$cm->instance."_".$queueditem->itemid.'.txt';
+                $filename = $title;
+            } else {
+                plagiarism_turnitin_activitylog('File content not found on submission: '.$queueditem->identifier, 'PP_NO_FILE');
+                mtrace('File content not found on submission. Identifier: '.$queueditem->identifier);
+                $errorcode = 9;
+            }
 
-            $message = $receipt->build_message($input);
-            $receipt->send_message($user->id, $message, $cm->course);
+            break;
+    }
 
-            // Output a message in the cron for successfull submission to Turnitin.
-            $outputvars = new stdClass();
-            $outputvars->title = $title;
-            $outputvars->submissionid = $tiisubmissionid;
-            $outputvars->assignmentname = $moduledata->name;
-            $outputvars->coursename = $coursedata->turnitin_ctl;
+    // Save failed submission and don't process any further.
+    if ($errorcode != 0) {
+        $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, $errorcode);
+        return;
+    }
 
-            mtrace(get_string('cronsubmittedsuccessfully', 'plagiarism_turnitin', $outputvars));
-        } catch (Exception $e) {
+    // Read the stored file/content into a temp file for submitting.
+    $submissiontitle = explode('.', $title);
 
-            // Save that submission errored.
-            $submissionerrormsg = get_string('pp_submission_error', 'plagiarism_turnitin').' '.$e->getMessage();
-            $pluginturnitin->save_submission($cm, $user->id, $queueditem->id, $queueditem->identifier, 'error', null,
-                                    $queueditem->submitter, $queueditem->itemid, $queueditem->submissiontype,
-                                    $queueditem->attempt, 0, $submissionerrormsg);
+    // Initialise file string array for naming the file.
+    $filestring = [$submissiontitle[0], $cm->id];
 
-            $errorstring = (empty($queueditem->externalid)) ? "pp_createsubmissionerror" : "pp_updatesubmissionerror";
-            $turnitincomms->handle_exceptions($e, $errorstring, false);
+    // Only include user's name and id if we're not using blind marking and student privacy.
+    if ( empty($moduledata->blindmarking) && empty($config->plagiarism_turnitin_enablepseudo) ) {
+        $userdetails = [
+            $user->id,
+            $user->firstname,
+            $user->lastname,
+        ];
 
-            // Output error in the cron.
-            mtrace('-------------------------');
-            mtrace(get_string('pp_submission_error', 'plagiarism_turnitin').': '.$e->getMessage());
-            mtrace('User:  '.$user->id.' - '.$user->firstname.' '.$user->lastname.' ('.$user->email.')');
-            mtrace('Course Module: '.$cm->id.'');
-            mtrace('-------------------------');
+        $filestring = array_merge($userdetails, $filestring);
+    }
+
+    // Don't proceed if we can not create a tempfile.
+    try {
+        $tempfile = plagiarism_turnitin_tempfile($filestring, $filename);
+    } catch (Exception $e) {
+        $pluginturnitin->save_errored_submission($queueditem->id, $queueditem->attempt, 8);
+        return;
+    }
+
+    $fh = fopen($tempfile, "w");
+    fwrite($fh, $textcontent);
+    fclose($fh);
+
+    // Create submission object.
+    $submission = new TiiSubmission();
+    $submission->setAssignmentId($syncassignment['tiiassignmentid']);
+    if ($apimethod == "replaceSubmission") {
+        $submission->setSubmissionId($queueditem->externalid);
+    }
+    $submission->setTitle($title);
+    $submission->setAuthorUserId($user->tiiuserid);
+
+    // Account for submission by teacher in assignment module.
+    $submission->setSubmitterUserId($user->tiiuserid);
+    $submission->setRole('Learner');
+
+    if ($queueditem->userid != $queueditem->submitter) {
+
+        $instructor = new turnitin_user($queueditem->submitter, 'Instructor');
+
+        // These should be true but in case of an edge case where a user has been deleted in Tii.
+        if ($instructor->edit_tii_user() && $instructor->join_user_to_class($coursedata->turnitin_cid)) {
+
+            $submission->setSubmitterUserId($instructor->tiiuserid);
+            $submission->setRole('Instructor');
         }
+    }
+
+    $submission->setSubmissionDataPath($tempfile);
+
+    // Initialise Comms Object.
+    $turnitincomms = new turnitin_comms();
+    $turnitincall = $turnitincomms->initialise_api();
+
+    try {
+        $response = $turnitincall->$apimethod($submission);
+        $newsubmission = $response->getSubmission();
+        $tiisubmissionid = $newsubmission->getSubmissionId();
+
+        $pluginturnitin->save_submission($cm, $user->id, $queueditem->id, $queueditem->identifier, 'success', $tiisubmissionid,
+                                         $queueditem->submitter, $queueditem->itemid, $queueditem->submissiontype, $queueditem->attempt);
+
+        // Delete the tempfile.
+        if (!is_null($tempfile)) {
+            unlink($tempfile);
+        }
+
+        plagiarism_turnitin_lock_anonymous_marking($cm->id);
+
+        // Send a message to the user's Moodle inbox with the digital receipt.
+        $receipt = new pp_receipt_message();
+        $input = [
+            'firstname' => $user->firstname,
+            'lastname' => $user->lastname,
+            'submission_title' => $title,
+            'assignment_name' => $moduledata->name,
+            'course_fullname' => $coursedata->turnitin_ctl,
+            'submission_date' => date('d-M-Y h:iA'),
+            'submission_id' => $tiisubmissionid,
+        ];
+
+        $message = $receipt->build_message($input);
+        $receipt->send_message($user->id, $message, $cm->course);
+
+        // Output a message in the cron for successfull submission to Turnitin.
+        $outputvars = new stdClass();
+        $outputvars->title = $title;
+        $outputvars->submissionid = $tiisubmissionid;
+        $outputvars->assignmentname = $moduledata->name;
+        $outputvars->coursename = $coursedata->turnitin_ctl;
+
+        mtrace(get_string('cronsubmittedsuccessfully', 'plagiarism_turnitin', $outputvars));
+    } catch (Exception $e) {
+
+        // Save that submission errored.
+        $submissionerrormsg = get_string('pp_submission_error', 'plagiarism_turnitin').' '.$e->getMessage();
+        $pluginturnitin->save_submission($cm, $user->id, $queueditem->id, $queueditem->identifier, 'error', null,
+                                         $queueditem->submitter, $queueditem->itemid, $queueditem->submissiontype,
+                                         $queueditem->attempt, 0, $submissionerrormsg);
+
+        $errorstring = (empty($queueditem->externalid)) ? "pp_createsubmissionerror" : "pp_updatesubmissionerror";
+        $turnitincomms->handle_exceptions($e, $errorstring, false);
+
+        // Output error in the cron.
+        mtrace('-------------------------');
+        mtrace(get_string('pp_submission_error', 'plagiarism_turnitin').': '.$e->getMessage());
+        mtrace('User:  '.$user->id.' - '.$user->firstname.' '.$user->lastname.' ('.$user->email.')');
+        mtrace('Course Module: '.$cm->id.'');
+        mtrace('-------------------------');
     }
 }
 

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2025103107;
+$plugin->version = 2025103109;
 
 $plugin->release = "4.5+";
 $plugin->requires = 2018051700;


### PR DESCRIPTION
Adds a new ad hoc task, `adhoc_send_submission`. This is an ad hoc task that sends a single submission to Turntin.
The user can choose whether to this enable ad hoc task. If it's disabled, the submissions will be sent sequentially as they were before. If it's enabled, the submissions will be processed in parallel.
Each time the scheduled task runs (every 5 minutes) instead of grabbing 100 submissions and trying to send them sequentially, we grab all queued submissions and spin up an ad hoc task for each one. The site admin is free to configure a limit on how many of these tasks can run at any given time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how queued submissions are drained (unlimited fan-out vs 100/run) and relies on Moodle ad-hoc concurrency limits; misconfiguration or duplicate task queuing could increase Turnitin API load or race on the same queue rows.
> 
> **Overview**
> Adds an admin **Enable ad-hoc task processing for the submission queue** setting (default off) and persists `plagiarism_turnitin_enableadhocsubmissions` with other plugin config.
> 
> When enabled, the scheduled **send submissions** task no longer uploads files itself: it loads **all** `queued`/`pending` rows (no per-run cap), verifies Turnitin connectivity, and enqueues one **`adhoc_send_submission`** task per item. That ad-hoc task allows concurrent runs and calls the new shared **`plagiarism_turnitin_send_single_submission`** helper. When disabled, behavior stays the same as before—still capped at **`PLAGIARISM_TURNITIN_CRON_SUBMISSIONS_LIMIT` (100)** and processed sequentially in the scheduled task.
> 
> The large **`lib.php`** change is mostly extracting the per-item upload pipeline into **`plagiarism_turnitin_send_single_submission`**, with loop `continue` semantics replaced by early `return` so both paths share one implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776a3d9cc9b5e9a4e013a7a6f79a191b0b6d1171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->