### PR TITLE
Remove restriction on editing exclusions after first submission

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -340,14 +340,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 }
             }
 
-            // Check if files have already been submitted and disable exclude biblio and quoted if turnitin is enabled.
-            if ($cmid != 0) {
-                if ($DB->record_exists('plagiarism_turnitin_files', ['cm' => $cmid])) {
-                    $mform->disabledIf('plagiarism_exclude_biblio', 'use_turnitin');
-                    $mform->disabledIf('plagiarism_exclude_quoted', 'use_turnitin');
-                }
-            }
-
             // Set the default value for each option as the value we have stored.
             foreach ($plagiarismelements as $element) {
                 if (isset($plagiarismvalues[$element])) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Similarity exclusion settings can be changed post-submission, which may alter how reports are interpreted or require Turnitin-side updates; scope is limited to two form fields in the activity editor.
> 
> **Overview**
> Teachers can again change **exclude bibliography** and **exclude quoted text** on the Turnitin activity settings form after at least one submission exists for that activity.
> 
> The plugin no longer checks `plagiarism_turnitin_files` for the course module and disables those two fields when Turnitin is enabled. Other behavior is unchanged: fields still follow the existing `use_turnitin` disable rules for the rest of the settings, and saved values continue to flow to Turnitin on assignment sync via `setBibliographyExcluded` / `setQuotedExcluded`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdeeb6c4eb26f857dd643f421288a8f51811f055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->