### PR TITLE
Merge to QA

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -340,14 +340,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 }
             }
 
-            // Check if files have already been submitted and disable exclude biblio and quoted if turnitin is enabled.
-            if ($cmid != 0) {
-                if ($DB->record_exists('plagiarism_turnitin_files', ['cm' => $cmid])) {
-                    $mform->disabledIf('plagiarism_exclude_biblio', 'use_turnitin');
-                    $mform->disabledIf('plagiarism_exclude_quoted', 'use_turnitin');
-                }
-            }
-
             // Set the default value for each option as the value we have stored.
             foreach ($plagiarismelements as $element) {
                 if (isset($plagiarismvalues[$element])) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small Moodle form behavior change only; no auth or submission pipeline changes, though post-submission exclusion edits may affect Turnitin originality report settings when saved.
> 
> **Overview**
> Removes logic in **`add_settings_form_to_activity_page`** that greyed out **exclude bibliography** and **exclude quoted text** on activity edit when the course module already had rows in `plagiarism_turnitin_files`.
> 
> Teachers editing an existing Turnitin-enabled activity can change those two options even after students have submitted; other Turnitin fields still follow existing `use_turnitin` and lock behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b9b59f11aca6387f704c1d280212e8baa44d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->