### PR TITLE
Don't show DV link for group nonsubmitters with online text

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -765,6 +765,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $coursedata = $this->get_course_data($cm->id, $cm->course);
         }
 
+        $isnonsubmitterforgroupassign = false;
+
         // Create module object.
         $moduleclass = "turnitin_".$cm->modname;
         $moduleobject = new $moduleclass;
@@ -1060,11 +1062,21 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                             // This class is applied so that only the user who submitted or a tutor can open the DV.
                             $useropenclass = ($USER->id == $linkarray["userid"] || $istutor) ? 'pp_origreport_open' : '';
 
+                            if ($cm->modname === 'assign' && !$istutor && !empty($plagiarismfile)) {
+                                $context = context_course::instance($cm->course);
+                                $assign = new assign($context, $cm, null);
+                                if ($assign->get_instance()->teamsubmission && isset($USER->id) && $plagiarismfile->submitter != $USER->id) {
+                                    $isnonsubmitterforgroupassign = true;
+                                }
+                            }
+
                             // Output container for OR Score.
-                            $ordivclass = 'row_score pp_origreport '.$useropenclass.' origreport_'.$plagiarismfile->externalid.'_'.
-                                $linkarray["cmid"];
-                            $output .= html_writer::tag('div', $orscorehtml, ['class' => $ordivclass, 'tabindex' => '0',
-                                'role' => 'link']);
+                            if (!$isnonsubmitterforgroupassign) {
+                                $ordivclass = 'row_score pp_origreport '.$useropenclass.' origreport_'.$plagiarismfile->externalid.'_'.
+                                    $linkarray["cmid"];
+                                $output .= html_writer::tag('div', $orscorehtml, ['class' => $ordivclass, 'tabindex' => '0',
+                                    'role' => 'link']);
+                            }
                         }
 
                         if (($plagiarismfile->orcapable == 0 && !is_null($plagiarismfile->orcapable))) {
@@ -1326,12 +1338,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             ' Course ID: '.$coursedata->turnitin_cid.' TII assignment ID: '.$turnitinassignid.' -->');
 
         // If we're displaying links for an assignment with group submissions enabled, only show the DV link to the submitting student
-        if ($cm->modname === 'assign' && !$istutor && !empty($plagiarismfile)) {
-            $context = context_course::instance($cm->course);
-            $assign = new assign($context, $cm, null);
-            if ($assign->get_instance()->teamsubmission && isset($USER->id) && $plagiarismfile->submitter != $USER->id) {
-                $output .= html_writer::tag('div', get_string('nonsubmittingstudentinfo', 'plagiarism_turnitin'), ['class' => 'tii_nonsubmitter_info']);
-            }
+        if ($isnonsubmitterforgroupassign) {
+            $output .= html_writer::tag('div', get_string('nonsubmittingstudentinfo', 'plagiarism_turnitin'), ['class' => 'tii_nonsubmitter_info']);
         }
 
         return $output;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small display/access tweak in Turnitin link rendering for group assign; no changes to submission or grading logic.
> 
> **Overview**
> For **team submissions** on assignments, students who did not submit the work were still seeing the **originality report / Document Viewer** UI (including for **online text**), even though only the submitting student should open the DV.
> 
> This change introduces a shared **`$isnonsubmitterforgroupassign`** flag in `get_links()`: when the activity is assign with team submission enabled, the viewer is a non-tutor, and **`plagiarismfile->submitter`** is not the current user, the **originality score row** (the clickable DV launch) is **not rendered**. The existing **`nonsubmittingstudentinfo`** message at the end of the output now uses the same flag instead of duplicating the assign/team/submitter checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0a67df6590afcc6d37006f0ee7f8148c5d26e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->