### PR TITLE
INT-24996 Fix forum submission identifiers

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -820,8 +820,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                   $identifier = sha1('quiz_attempt user'.$attempt->get_userid().' cm'.$cm->id.
                                      ' slot'.$linkarray["itemid"].' attempt'.$attempt->get_attempt_number());
                   $oldidentifier = sha1($content.$linkarray["itemid"]);
-                }
-                else {
+                } else if ($submissiontype === 'forum_post') {
+                  $identifier = sha1('forum_post user'.$linkarray['userid'].' cm'.$cm->id.' '.$content);
+                  $oldidentifier = sha1($content);
+                } else {
                   $identifier = sha1($content);
                 }
             }
@@ -2886,7 +2888,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $eventdata['other']['content'] = $moodlesubmission->message;
             }
 
-            $identifier = sha1($eventdata['other']['content']);
+            if ($cm->modname == 'forum') {
+                $identifier = sha1('forum_post user'.$author.' cm'.$cm->id.' '.$eventdata['other']['content']);
+            } else {
+                $identifier = sha1($eventdata['other']['content']);
+            }
 
             // Check if content has been submitted before and return if so.
             $result = $this->queue_submission_to_turnitin(

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2025103109;
+$plugin->version = 2025103111;
 
 $plugin->release = "4.5+";
 $plugin->requires = 2018051700;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how forum submissions are deduplicated and looked up in Turnitin; incorrect hashing could miss reports or queue duplicates, though legacy identifiers are still queried for display.
> 
> **Overview**
> Forum Turnitin rows are keyed by **content-only** `sha1` hashes, which can collide across users or activities and can disagree with what gets queued on submit. This change uses a **composite hash** (`forum_post user` + userid + cm id + content) when queuing forum text in `event_handler` and when resolving originality links in `get_links`.
> 
> **`get_links`** also keeps **`oldidentifier = sha1(content)`** so existing `plagiarism_turnitin_files` records still match, following the same new/old pattern used for quiz answers. Plugin **version** is bumped to `2025103111`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c16bb61d5abc1faebf3a83d7c6a6085063bf7aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->