### PR TITLE
INT-25022 Fix Assignment online submission identifiers

### DIFF
--- a/classes/modules/turnitin_assign.class.php
+++ b/classes/modules/turnitin_assign.class.php
@@ -160,6 +160,12 @@ class turnitin_assign {
     public function get_onlinetext($userid, $cm) {
         global $DB;
 
+        // Team submissions are stored with userid 0.
+        $assign = $DB->get_record('assign', ['id' => $cm->instance], 'teamsubmission');
+        if (!empty($assign->teamsubmission)) {
+            $userid = 0;
+        }
+
         // Get latest text content submitted as we do not have submission id.
         $submissions = $DB->get_records_select('assign_submission', ' userid = ? AND assignment = ? ',
                                         [$userid, $cm->instance], 'id DESC', 'id', 0, 1);

--- a/classes/modules/turnitin_assign.class.php
+++ b/classes/modules/turnitin_assign.class.php
@@ -158,30 +158,11 @@ class turnitin_assign {
      * @throws dml_exception
      */
     public function get_onlinetext($userid, $cm) {
-        global $CFG, $DB;
+        global $DB;
 
-        $assign = $DB->get_record('assign', ['id' => $cm->instance], 'teamsubmission');
-        if (!empty($assign->teamsubmission)) {
-            // Team submissions are keyed by groupid (userid is stored as 0).
-            require_once($CFG->dirroot . '/mod/assign/locallib.php');
-            $context = context_course::instance($cm->course);
-            $assignment = new assign($context, $cm, null);
-            $group = $assignment->get_submission_group($userid);
-
-            $onlinetextdata = new stdClass();
-            if (empty($group)) {
-                $onlinetextdata->itemid = 0;
-                return $onlinetextdata;
-            }
-
-            $submissions = $DB->get_records_select('assign_submission', ' assignment = ? AND groupid = ? ',
-                                            [$cm->instance, $group->id], 'id DESC', 'id', 0, 1);
-        } else {
-            // Get latest text content submitted as we do not have submission id.
-            $submissions = $DB->get_records_select('assign_submission', ' userid = ? AND assignment = ? ',
-                                            [$userid, $cm->instance], 'id DESC', 'id', 0, 1);
-        }
-
+        // Get latest text content submitted as we do not have submission id.
+        $submissions = $DB->get_records_select('assign_submission', ' userid = ? AND assignment = ? ',
+                                        [$userid, $cm->instance], 'id DESC', 'id', 0, 1);
         $submission = end($submissions);
         $moodletextsubmission = $DB->get_record('assignsubmission_onlinetext',
                                             ['submission' => $submission->id], 'onlinetext, onlineformat');

--- a/classes/modules/turnitin_assign.class.php
+++ b/classes/modules/turnitin_assign.class.php
@@ -158,17 +158,30 @@ class turnitin_assign {
      * @throws dml_exception
      */
     public function get_onlinetext($userid, $cm) {
-        global $DB;
+        global $CFG, $DB;
 
-        // Team submissions are stored with userid 0.
         $assign = $DB->get_record('assign', ['id' => $cm->instance], 'teamsubmission');
         if (!empty($assign->teamsubmission)) {
-            $userid = 0;
+            // Team submissions are keyed by groupid (userid is stored as 0).
+            require_once($CFG->dirroot . '/mod/assign/locallib.php');
+            $context = context_course::instance($cm->course);
+            $assignment = new assign($context, $cm, null);
+            $group = $assignment->get_submission_group($userid);
+
+            $onlinetextdata = new stdClass();
+            if (empty($group)) {
+                $onlinetextdata->itemid = 0;
+                return $onlinetextdata;
+            }
+
+            $submissions = $DB->get_records_select('assign_submission', ' assignment = ? AND groupid = ? ',
+                                            [$cm->instance, $group->id], 'id DESC', 'id', 0, 1);
+        } else {
+            // Get latest text content submitted as we do not have submission id.
+            $submissions = $DB->get_records_select('assign_submission', ' userid = ? AND assignment = ? ',
+                                            [$userid, $cm->instance], 'id DESC', 'id', 0, 1);
         }
 
-        // Get latest text content submitted as we do not have submission id.
-        $submissions = $DB->get_records_select('assign_submission', ' userid = ? AND assignment = ? ',
-                                        [$userid, $cm->instance], 'id DESC', 'id', 0, 1);
         $submission = end($submissions);
         $moodletextsubmission = $DB->get_record('assignsubmission_onlinetext',
                                             ['submission' => $submission->id], 'onlinetext, onlineformat');

--- a/lib.php
+++ b/lib.php
@@ -2656,8 +2656,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
                 if ($previoussubmission) {
                     // Don't submit if submission hasn't changed.
-                    if (in_array($previoussubmission->statuscode, ["success", "error"])
-                            && $timemodified <= $previoussubmission->lastmodified) {
+                    if ($timemodified <= $previoussubmission->lastmodified) {
                         return true;
                     } else if ($moduledata->resubmission_allowed) {
                         // Replace submission in the specific circumstance where Turnitin can accommodate resubmissions.

--- a/lib.php
+++ b/lib.php
@@ -823,6 +823,13 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 } else if ($submissiontype === 'forum_post') {
                   $identifier = sha1('forum_post user'.$linkarray['userid'].' cm'.$cm->id.' '.$content);
                   $oldidentifier = sha1($content);
+                } else if ($cm->modname == 'assign') {
+                    $itemid = $moduleobject->get_onlinetext(
+                        !empty($moduledata->teamsubmission) ? 0 : $linkarray['userid'],
+                        $cm
+                    )->itemid;
+                    $identifier = sha1('text_content cm'.$cm->id.' itemid'.$itemid.' '.$content);
+                    $oldidentifier = sha1($content);
                 } else {
                   $identifier = sha1($content);
                 }
@@ -1548,9 +1555,13 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     // Get latest submission.
                     $moduleobject = new turnitin_assign();
                     $latesttext = $moduleobject->get_onlinetext($submissiondata->userid, $cm);
-                    $latestidentifier = sha1($latesttext->onlinetext);
+                    $latestidentifier = sha1(
+                        'text_content cm'.$cm->id.' itemid'.$latesttext->itemid.' '.$latesttext->onlinetext
+                    );
+                    $oldlatestidentifier = sha1($latesttext->onlinetext);
                     // Check submission being graded is latest.
-                    if ($submissiondata->identifier != $latestidentifier) {
+                    if ($submissiondata->identifier != $latestidentifier
+                            && $submissiondata->identifier != $oldlatestidentifier) {
                         $gbupdaterequired = false;
                     }
                 }
@@ -2890,6 +2901,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
             if ($cm->modname == 'forum') {
                 $identifier = sha1('forum_post user'.$author.' cm'.$cm->id.' '.$eventdata['other']['content']);
+            } else if ($cm->modname == 'assign') {
+                $identifier = sha1('text_content cm'.$cm->id.' itemid'.$eventdata['objectid'].' '.
+                    $eventdata['other']['content']);
             } else {
                 $identifier = sha1($eventdata['other']['content']);
             }

--- a/lib.php
+++ b/lib.php
@@ -824,10 +824,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                   $identifier = sha1('forum_post user'.$linkarray['userid'].' cm'.$cm->id.' '.$content);
                   $oldidentifier = sha1($content);
                 } else if ($cm->modname == 'assign') {
-                    $itemid = $moduleobject->get_onlinetext(
-                        !empty($moduledata->teamsubmission) ? 0 : $linkarray['userid'],
-                        $cm
-                    )->itemid;
+                    $itemid = $moduleobject->get_onlinetext($linkarray['userid'], $cm)->itemid;
                     $identifier = sha1('text_content cm'.$cm->id.' itemid'.$itemid.' '.$content);
                     $oldidentifier = sha1($content);
                 } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes submission deduplication and grade-sync matching for assign online text; backward-compatible identifiers reduce risk but altered skip-on-success behavior could affect resubmission edge cases.
> 
> **Overview**
> Assignment **online text** submissions now use a **stable identifier** (`sha1('text_content cm… itemid… ' + content)`) instead of hashing only the body text, aligned with forum/quiz handling.
> 
> The same formula is applied when **building plagiarism links**, **queuing events**, and when **deciding whether GradeMark sync applies to the latest attempt**. **Legacy** `sha1(content)` values are still recognized for link lookup and grade updates.
> 
> **Re-queue logic** for unchanged file/text rows no longer treats `success`/`error` status alone as a skip; resubmission is gated only on whether Moodle’s `timemodified` is newer than the stored Turnitin row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd237d84cf03747cf5ff64dacfda4a51569e94a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->