### PR TITLE
INT-25022 add null check for latesttext

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1552,14 +1552,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     // Get latest submission.
                     $moduleobject = new turnitin_assign();
                     $latesttext = $moduleobject->get_onlinetext($submissiondata->userid, $cm);
-                    $latestidentifier = sha1(
-                        'text_content cm'.$cm->id.' itemid'.$latesttext->itemid.' '.$latesttext->onlinetext
-                    );
-                    $oldlatestidentifier = sha1($latesttext->onlinetext);
-                    // Check submission being graded is latest.
-                    if ($submissiondata->identifier != $latestidentifier
-                            && $submissiondata->identifier != $oldlatestidentifier) {
-                        $gbupdaterequired = false;
+                    if (!empty($latesttext)) {
+                        $latestidentifier = sha1(
+                            'text_content cm'.$cm->id.' itemid'.$latesttext->itemid.' '.$latesttext->onlinetext
+                        );
+                        $oldlatestidentifier = sha1($latesttext->onlinetext);
+                        // Check submission being graded is latest.
+                        if ($submissiondata->identifier != $latestidentifier
+                                && $submissiondata->identifier != $oldlatestidentifier) {
+                            $gbupdaterequired = false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single defensive guard in grade-sync path; when online text is absent, latest-attempt validation is skipped instead of erroring.
> 
> **Overview**
> When syncing Turnitin grades back into Moodle for **assign** submissions with type `text_content`, the plugin compares stored identifiers against the latest online text from `get_onlinetext()`.
> 
> This change wraps that comparison in **`if (!empty($latesttext))`**, so the code no longer reads `itemid` / `onlinetext` or builds SHA1 identifiers when there is no online text record (avoiding null/empty-object failures during grade sync).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330defc1f272472aaaf27969b462512a070fb50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->