### PR TITLE
INT-25081 Allow uppercase file extensions

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3447,7 +3447,7 @@ function plagiarism_turnitin_send_single_submission($pluginturnitin, $queueditem
                 $acceptanyfiletype = (!empty($settings["plagiarism_allow_non_or_submissions"])) ? 1 : 0;
                 $filename = $file->get_filename();
                 $pathinfo = pathinfo($filename);
-                $extension = isset($pathinfo['extension']) ? $pathinfo['extension'] : '';
+                $extension = strtolower(isset($pathinfo['extension']) ? $pathinfo['extension'] : '');
                 if (!$acceptanyfiletype && !in_array('.'.$extension, $turnitinacceptedfiles)) {
                     $errorstring = 'File with ID '.$queueditem->id.' cannot be sent to turnitin: File format is not supported. The filename is '
                       .$file->get_filename(). ' and the extension is '.$extension;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line normalization in file-type validation; aligns cron behavior with existing queue-time checks and only broadens acceptance for valid types with non-lowercase extensions.
> 
> **Overview**
> **Queued Turnitin file submissions** with uppercase extensions (e.g. `Report.PDF`) were incorrectly rejected during the cron send path with error code 16, while the same files passed validation when queued via `queue_submission_to_turnitin`.
> 
> The cron handler in `plagiarism_turnitin_send_single_submission` now applies **`strtolower()`** to the parsed extension before comparing against `$turnitinacceptedfiles`, matching the lowercase extension list and the logic already used when submissions are first queued.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b7f6c8e62b314be46eaf024885aeb1960757640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->