### PR TITLE
 INT-24980 Release to QA

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3447,7 +3447,7 @@ function plagiarism_turnitin_send_single_submission($pluginturnitin, $queueditem
                 $acceptanyfiletype = (!empty($settings["plagiarism_allow_non_or_submissions"])) ? 1 : 0;
                 $filename = $file->get_filename();
                 $pathinfo = pathinfo($filename);
-                $extension = isset($pathinfo['extension']) ? $pathinfo['extension'] : '';
+                $extension = strtolower(isset($pathinfo['extension']) ? $pathinfo['extension'] : '');
                 if (!$acceptanyfiletype && !in_array('.'.$extension, $turnitinacceptedfiles)) {
                     $errorstring = 'File with ID '.$queueditem->id.' cannot be sent to turnitin: File format is not supported. The filename is '
                       .$file->get_filename(). ' and the extension is '.$extension;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line validation fix in the cron submission path; no auth, data model, or API contract changes.
> 
> **Overview**
> **Case-insensitive file extension check** when the cron job sends queued file submissions to Turnitin.
> 
> In `plagiarism_turnitin_send_single_submission`, the extension parsed from the filename is now passed through `strtolower` before it is checked against `$turnitinacceptedfiles`. That matches the behavior already used when submissions are first queued in `queue_submission_to_turnitin`, so uploads such as `essay.PDF` or `paper.Docx` are no longer marked unsupported (error code 16) during cron processing while the same file would have been accepted at queue time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9277cb107bafe7ed530d2a33e6939f086c8bb681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->