### PR TITLE
INT-25162 release notes 29/07/2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+### Date:       2026-July-29
+### Release:    v2026072901
+
+---
+
+#### Implemented Ad-Hoc Tasks for Sending Submissions
+An option is now available in the plugin settings to enable parralel processing for submissions.
+When this is enabled, submissions will be sent to Turnitin asynchronously.
+
+#### Implemented Grade Sync Scheduled Task
+Grades will now be synced automatically as a scheduled task instead of syncing only when an instructor interacts with a similarity report.
+
+#### Fixed Group Submission ID Generation
+An issue was observed where two or more group submissions with the same text could be linked to the same similarity report. This has now been fixed.
+
+#### Fixed Unsupported Filetype bug
+A bug was found where unsupported file types could not be uploaded, when the assignment was set to allow any file type. This is now fixed.
+
+#### Able to Edit Bibiliography Settings After Submission Has Been Made
+We added the ability to edit bibliography/quoted materials settings after the first submission has been made to an assignment, bringing this integration in line with Feedback Studio's native functionality.
+
+---
+
 ### Date:       2025-October-29
 ### Release:    v2025102901
 

--- a/version.php
+++ b/version.php
@@ -22,10 +22,10 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2025103111;
+$plugin->version = 2026072901;
 
 $plugin->release = "4.5+";
-$plugin->requires = 2018051700;
+$plugin->requires = 2024100700;
 $plugin->component = 'plagiarism_turnitin';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
* Added release notes to changelog.md
* Bumped plugin version
* Bumped required Moodle version to 4.5.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime code changes in this diff.
> 
> **Overview**
> Prepares the **v2026072901** release by documenting shipped work in `CHANGELOG.md` and aligning plugin metadata in `version.php`.
> 
> The new changelog entry covers ad-hoc/async submission sending, scheduled grade sync, group submission ID fixes, unsupported filetype uploads when “any file type” is allowed, and post-submission bibliography/quoted-materials settings.
> 
> **Version bumps:** plugin version to `2026072901` and minimum Moodle core to `2024100700` (4.5.0), matching the stated **4.5+** release line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98bafc710012ece0a58bda4c9c087bf3ea30b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->