### PR TITLE
INT-25188 Use html_to_text for online text submissions

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3520,7 +3520,9 @@ function plagiarism_turnitin_send_single_submission($pluginturnitin, $queueditem
             $forumpost = $DB->get_record_select('forum_posts', " userid = ? AND id = ? ", [$user->id, $queueditem->itemid]);
 
             if ($forumpost) {
-                $textcontent = strip_tags($forumpost->message);
+                // html_to_text() strips tags and decodes HTML entities (e.g. &amp; becomes &), matching
+                // the behaviour used for assign/workshop text_content submissions.
+                $textcontent = html_to_text($forumpost->message);
                 $title = 'forumpost_'.$user->id."_".$cm->id."_".$cm->instance."_".$queueditem->itemid.'.txt';
                 $filename = $title;
             } else {

--- a/tests/modules/turnitin_forum_test.php
+++ b/tests/modules/turnitin_forum_test.php
@@ -78,6 +78,27 @@ final class turnitin_forum_test extends \advanced_testcase {
     }
 
     /**
+     * Moodle stores forum post content as HTML, so special characters are encoded as entities
+     * (e.g. "&" becomes "&amp;"). Verify that html_to_text() — used in the forum submission
+     * pipeline — decodes these entities, preventing literal "&amp;" from appearing in the
+     * Turnitin Document Viewer.
+     */
+    public function test_forum_post_html_entities_are_decoded_for_submission(): void {
+        $this->resetAfterTest();
+
+        // Moodle's TinyMCE/Atto editor stores "&" as "&amp;" in forum_posts.message.
+        $htmlmessage = '<p>Cats &amp; dogs are great. 2 &lt; 3 and 4 &gt; 1.</p>';
+        $plaintextcontent = html_to_text($htmlmessage);
+
+        $this->assertStringContainsString('&', $plaintextcontent);
+        $this->assertStringNotContainsString('&amp;', $plaintextcontent);
+        $this->assertStringNotContainsString('&lt;', $plaintextcontent);
+        $this->assertStringNotContainsString('&gt;', $plaintextcontent);
+        $this->assertStringContainsString('<', $plaintextcontent);
+        $this->assertStringContainsString('>', $plaintextcontent);
+    }
+
+    /**
      * Test to check that content returned by set content is the same as passed in array.
      */
     public function test_to_check_content_in_array_is_returned_by_set_content(): void {


### PR DESCRIPTION
This fixes a bug where the DV sees characters encoded as html, e.g. &amp; instead of the ampersand character.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to forum submission text normalization with a matching test; no auth, security, or grading logic touched.
> 
> **Overview**
> Forum posts sent to Turnitin now use **`html_to_text()`** instead of **`strip_tags()`** when building the text payload for the Document Viewer, so encoded characters (e.g. `&amp;`, `&lt;`, `&gt;`) are decoded the same way as assign/workshop online text submissions.
> 
> A unit test in **`turnitin_forum_test`** asserts that `html_to_text()` on typical editor HTML yields plain `&`, `<`, and `>` rather than entity literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4f9ba5a61e5fc286c39cccd9fc1ca29f2f10fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->