### PR TITLE
INT-24980 QA Release

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -3520,7 +3520,9 @@ function plagiarism_turnitin_send_single_submission($pluginturnitin, $queueditem
             $forumpost = $DB->get_record_select('forum_posts', " userid = ? AND id = ? ", [$user->id, $queueditem->itemid]);
 
             if ($forumpost) {
-                $textcontent = strip_tags($forumpost->message);
+                // html_to_text() strips tags and decodes HTML entities (e.g. &amp; becomes &), matching
+                // the behaviour used for assign/workshop text_content submissions.
+                $textcontent = html_to_text($forumpost->message);
                 $title = 'forumpost_'.$user->id."_".$cm->id."_".$cm->instance."_".$queueditem->itemid.'.txt';
                 $filename = $title;
             } else {

--- a/repo-metadata.yml
+++ b/repo-metadata.yml
@@ -1,3 +1,4 @@
+---
 schema_version: 1.0.0
 info:
   domain: Integrity

--- a/repo-metadata.yml
+++ b/repo-metadata.yml
@@ -1,0 +1,7 @@
+schema_version: 1.0.0
+info:
+  domain: Integrity
+  component: Integrations - strategic
+  security_class: 'Class A: Production'
+ownership:
+  team: Integrations

--- a/tests/modules/turnitin_forum_test.php
+++ b/tests/modules/turnitin_forum_test.php
@@ -78,6 +78,27 @@ final class turnitin_forum_test extends \advanced_testcase {
     }
 
     /**
+     * Moodle stores forum post content as HTML, so special characters are encoded as entities
+     * (e.g. "&" becomes "&amp;"). Verify that html_to_text() — used in the forum submission
+     * pipeline — decodes these entities, preventing literal "&amp;" from appearing in the
+     * Turnitin Document Viewer.
+     */
+    public function test_forum_post_html_entities_are_decoded_for_submission(): void {
+        $this->resetAfterTest();
+
+        // Moodle's TinyMCE/Atto editor stores "&" as "&amp;" in forum_posts.message.
+        $htmlmessage = '<p>Cats &amp; dogs are great. 2 &lt; 3 and 4 &gt; 1.</p>';
+        $plaintextcontent = html_to_text($htmlmessage);
+
+        $this->assertStringContainsString('&', $plaintextcontent);
+        $this->assertStringNotContainsString('&amp;', $plaintextcontent);
+        $this->assertStringNotContainsString('&lt;', $plaintextcontent);
+        $this->assertStringNotContainsString('&gt;', $plaintextcontent);
+        $this->assertStringContainsString('<', $plaintextcontent);
+        $this->assertStringContainsString('>', $plaintextcontent);
+    }
+
+    /**
      * Test to check that content returned by set content is the same as passed in array.
      */
     public function test_to_check_content_in_array_is_returned_by_set_content(): void {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized change to forum submission text preparation with a matching test; no auth, grading, or API contract changes beyond corrected plaintext content.
> 
> **Overview**
> Forum posts submitted to Turnitin now use **`html_to_text()`** instead of **`strip_tags()`** when building plaintext for upload, so HTML entities from Moodle’s editor (e.g. `&amp;`, `&lt;`, `&gt;`) are decoded and do not show literally in the Turnitin Document Viewer—aligned with assign/workshop **`text_content`** handling.
> 
> Adds **`repo-metadata.yml`** for Integrations ownership metadata and a unit test that asserts **`html_to_text()`** decodes entities in sample forum HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2673b4295d5e06d5d91c69491c317a02cf5557c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->